### PR TITLE
[REF] Overhauls `stats.correlate_images()`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 neuromaps
-=============
+=========
 
 The ``neuromaps`` toolbox is designed to help researchers make easy,
 statistically-rigorous comparisons between brain maps (or brain annotations).
@@ -22,7 +22,7 @@ with:
 
 .. code-block:: bash
 
-    git clone https://github.com/rmarkello/neuromaps
+    git clone https://github.com/netneurolab/neuromaps
     cd neuromaps
     pip install neuromaps
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,7 +11,7 @@ Reference API
 .. _ref_datasets:
 
 :mod:`neuromaps.datasets` - Dataset fetchers
-------------------------------------------------
+--------------------------------------------
 .. automodule:: neuromaps.datasets
    :no-members:
    :no-inherited-members:
@@ -39,7 +39,7 @@ Reference API
 .. _ref_images:
 
 :mod:`neuromaps.images` - Image and surface handling
---------------------------------------------------------
+----------------------------------------------------
 .. automodule:: neuromaps.images
    :no-members:
    :no-inherited-members:
@@ -68,7 +68,7 @@ Reference API
 .. _ref_nulls:
 
 :mod:`neuromaps.nulls` - Null models
-----------------------------------------
+------------------------------------
 .. automodule:: neuromaps.nulls
    :no-members:
    :no-inherited-members:
@@ -94,7 +94,7 @@ Reference API
 .. _ref_parcellating:
 
 :mod:`neuromaps.parcellate` - Parcellation utilities
---------------------------------------------------------
+----------------------------------------------------
 .. automodule:: neuromaps.parcellate
    :no-members:
    :no-inherited-members:
@@ -110,7 +110,7 @@ Reference API
 .. _ref_plotting:
 
 :mod:`neuromaps.plotting` - Plotting functions
---------------------------------------------------
+----------------------------------------------
 .. automodule:: neuromaps.plotting
    :no-members:
    :no-inherited-members:
@@ -126,7 +126,7 @@ Reference API
 .. _ref_points:
 
 :mod:`neuromaps.points` - Triangle mesh utilites
-----------------------------------------------------
+------------------------------------------------
 .. automodule:: neuromaps.points
     :no-members:
     :no-inherited-members:
@@ -143,7 +143,7 @@ Reference API
 .. _ref_resampling:
 
 :mod:`neuromaps.resampling` - Resampling workflows
-------------------------------------------------------
+--------------------------------------------------
 .. automodule:: neuromaps.resampling
     :no-members:
     :no-inherited-members:
@@ -159,7 +159,7 @@ Reference API
 .. _ref_stats:
 
 :mod:`neuromaps.stats` - Statistical functions
---------------------------------------------------
+----------------------------------------------
 .. automodule:: neuromaps.stats
     :no-members:
     :no-inherited-members:
@@ -170,14 +170,13 @@ Reference API
     :template: function.rst
     :toctree: generated/
 
-    neuromaps.stats.correlate_images
-    neuromaps.stats.efficient_pearsonr
-    neuromaps.stats.permtest_pearsonr
+    neuromaps.stats.compare_images
+    neuromaps.stats.permtest_metric
 
 .. _ref_transforms:
 
 :mod:`neuromaps.transforms` - Transformations between spaces
-----------------------------------------------------------------
+------------------------------------------------------------
 .. automodule:: neuromaps.transforms
    :no-members:
    :no-inherited-members:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,11 +32,11 @@ This package requires Python 3.7+. Assuming you have the correct version of
 Python installed, you can install ``neuromaps`` by opening a terminal and
 running the following:
 
-.. code-block:: bash
+.. .. code-block:: bash
 
-    pip install neuromaps
+..     pip install neuromaps
 
-Alternatively, you can install the most up-to-date version of from GitHub:
+.. Alternatively, you can install the most up-to-date version of from GitHub:
 
 .. code-block:: bash
 

--- a/examples/plot_spatial_nulls.py
+++ b/examples/plot_spatial_nulls.py
@@ -56,7 +56,7 @@ print(nsynth, genepc)
 # Once the images are resampled we can easily correlate them:
 
 from neuromaps import stats
-corr, pval = stats.correlate_images(nsynth, genepc)
+corr, pval = stats.compare_images(nsynth, genepc)
 print(f'Correlation: r = {corr:.02f}, p = {pval:.04f}')
 
 ###############################################################################
@@ -80,7 +80,7 @@ print(rotated.shape)
 
 ###############################################################################
 # We can supply the generated null array to the
-# :func:`neuromaps.stats.correlate_images` function and it will be used to
+# :func:`neuromaps.stats.compare_images` function and it will be used to
 # generate a non-parameteric p-value. The function assumes that the array
 # provided to the `nulls` parameter corresponds to the *first* dataset passed
 # to the function (i.e., `nsynth`).
@@ -88,7 +88,7 @@ print(rotated.shape)
 # Note that the correlation remains identical to that above but the p-value has
 # now changed, revealing that the correlation is no longer significant:
 
-corr, pval = stats.correlate_images(nsynth, genepc, nulls=rotated)
+corr, pval = stats.compare_images(nsynth, genepc, nulls=rotated)
 print(f'Correlation: r = {corr:.02f}, p = {pval:.04f}')
 
 ###############################################################################

--- a/neuromaps/__init__.py
+++ b/neuromaps/__init__.py
@@ -1,7 +1,7 @@
-__all__ = ['resample_images', 'correlate_images']
+__all__ = ['resample_images', 'compare_images']
 
 from neuromaps.resampling import resample_images
-from neuromaps.stats import correlate_images
+from neuromaps.stats import compare_images
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/neuromaps/tests/test_stats.py
+++ b/neuromaps/tests/test_stats.py
@@ -10,17 +10,17 @@ from neuromaps import stats
 
 
 @pytest.mark.xfail
-def test_correlate_images():
+def test_compare_images():
     assert False
 
 
-def test_permtest_pearsonr():
+def test_permtest_metric():
     rs = np.random.default_rng(12345678)
     x, y = rs.random(size=(2, 100))
-    r, p = stats.permtest_pearsonr(x, y)
+    r, p = stats.permtest_metric(x, y)
     assert np.allclose([r, p], [0.0345815411043023, 0.7192807192807192])
 
-    r, p = stats.permtest_pearsonr(np.c_[x, x[::-1]], np.c_[y, y])
+    r, p = stats.permtest_metric(np.c_[x, x[::-1]], np.c_[y, y])
     assert np.allclose(r, [0.0345815411043023, 0.03338608427980476])
     assert np.allclose(p, [0.7192807192807192, 0.7472527472527473])
 


### PR DESCRIPTION
Makes `stats.correlate_images()` more generic `stats.compare_images()`, which accepts any user-provided similarity metric callable (in addition to `'pearsonr'` and `'spearmanr`', as before).

Also updates `stats.permtest_pearsonr()` --> `stats.permtest_metric()` to reflect changes.