### PR TITLE
[FIX] Fix OSF info and json

### DIFF
--- a/neuromaps/datasets/_osf.py
+++ b/neuromaps/datasets/_osf.py
@@ -351,7 +351,7 @@ def get_url(fname, project, token=None):
         Project ID on OSF
     token : str, optional
         OSF personal access token for accessing restricted annotations. Will
-        also check the environmental variable 'neuromaps_OSF_TOKEN' if not
+        also check the environmental variable 'NEUROMAPS_OSF_TOKEN' if not
         provided; if that is not set no token will be provided and restricted
         annotations will be inaccessible. Default: None
 
@@ -393,7 +393,7 @@ def generate_release_json(fname, output=OSFJSON, root='annotations',
         the URL for the generated data will not be set. Default: None
     token : str, optional
         OSF personal access token for accessing restricted annotations. Will
-        also check the environmental variable 'neuromaps_OSF_TOKEN' if not
+        also check the environmental variable 'NEUROMAPS_OSF_TOKEN' if not
         provided; if that is not set no token will be provided and restricted
         annotations will be inaccessible. Default: None
 

--- a/neuromaps/datasets/_osf.py
+++ b/neuromaps/datasets/_osf.py
@@ -25,7 +25,9 @@ REDIR_KEYS = ['space', 'den']
 INFO_KEYS = ['source', 'refs', 'comments', 'demographics']
 
 # distribution JSON
-OSFJSON = resource_filename('neuromaps', 'data/osf.json')
+OSFJSON = resource_filename(
+    'neuromaps', os.path.join('datasets', 'data', 'osf.json')
+)
 
 
 def parse_filename(fname, return_ext=True, verbose=False):
@@ -150,9 +152,13 @@ def write_json(data, fname, root='annotations', indent=4):
         raise ValueError(f'Provided `root` must be a str. Received: {root}')
 
     # if `fname` already exists we want to update it, not overwrite it!
-    if os.path.isfile(fname):
+    output = {root: []}
+    if os.path.isfile(fname) and os.stat(fname).st_size != 0:
         output = parse_json(fname, [])
-    output[root] = data
+    if output.get(root) is None:
+        output[root] = []
+
+    output[root].extend(data)
 
     # save to disk
     with open(fname, 'w', encoding='utf-8') as dest:
@@ -245,7 +251,11 @@ def check_missing_keys(fname, root='annotations'):
         Missing keys for each entry in `fname`
     """
 
-    data = parse_json(fname, root=root)
+    try:
+        data = parse_json(fname, root=root)
+    except TypeError:
+        if isinstance(fname, dict):
+            data = [fname]
 
     is_missing_keys, info = False, []
     for item in data:
@@ -286,8 +296,9 @@ def generate_auto_keys(item):
     volfmt = pref = '_res-{res}_feature.nii.gz'
 
     # check format by checking 'hemi'
-    is_surface = item['den'] or item['hemi'] or item['format'] == 'surface'
-    is_volume = item['res'] or item['format'] == 'volume'
+    is_surface = ('den' in item or 'hemi' in item
+                  or item.get('format') == 'surface')
+    is_volume = 'res' in item or item.get('format') == 'volume'
 
     if is_surface:  # this is surface file
         item['format'] = 'surface'
@@ -296,8 +307,8 @@ def generate_auto_keys(item):
         item['format'] = 'volume'
         item['fname'] = volfmt.format(**item)
     else:
-        print('Missing keys to determine surface/volumetric format of data; '
-              'fname keys not generated')
+        raise ValueError('Missing keys to determine surface/volumetric format '
+                         'of data')
 
     item['rel_path'] = os.path.join(*[
         item[key] for key in ['source', 'desc', 'space']
@@ -306,7 +317,8 @@ def generate_auto_keys(item):
     # check file existence
     filepath = os.path.join(item['rel_path'], item['fname'])
     if item['fname'] is not None and os.path.isfile(filepath):
-        item['checksum'] = _md5_sum_file(filepath)
+        if item.get('checksum') is None:
+            item['checksum'] = _md5_sum_file(filepath)
 
     return item
 
@@ -403,7 +415,7 @@ def generate_release_json(fname, output=OSFJSON, root='annotations',
         Path to filename where output JSON was saved
     """
 
-    output = []
+    info = []
     for item in parse_json(fname, root=root):
         item = clean_minimal_keys(generate_auto_keys(item))
         # fetch URL for file if needed (and project is specified)
@@ -411,6 +423,6 @@ def generate_release_json(fname, output=OSFJSON, root='annotations',
                 and project is not None):
             fn = os.path.join(item['rel_path'], item['fname'])
             item['url'] = [project, get_url(fn, project=project, token=token)]
-        output.append({key: item[key] for key in MINIMAL_KEYS if key in item})
-    fname = write_json(output, output, root='annotations')
+        info.append({key: item[key] for key in MINIMAL_KEYS if key in item})
+    fname = write_json(info, output, root='annotations')
     return fname

--- a/neuromaps/datasets/annotations.py
+++ b/neuromaps/datasets/annotations.py
@@ -173,12 +173,12 @@ def fetch_annotation(*, source=None, desc=None, space=None, den=None, res=None,
         list of filepaths instead of the standard dictionary. Default: False
     token : str, optional
         OSF personal access token for accessing restricted annotations. Will
-        also check the environmental variable 'neuromaps_OSF_TOKEN' if not
+        also check the environmental variable 'NEUROMAPS_OSF_TOKEN' if not
         provided; if that is not set no token will be provided and restricted
         annotations will be inaccessible. Default: None
     data_dir : str, optional
         Path to use as data directory. If not specified, will check for
-        environmental variable 'neuromaps_DATA'; if that is not set, will
+        environmental variable 'NEUROMAPS_DATA'; if that is not set, will
         use `~/neuromaps-data` instead. Default: None
     verbose : int, optional
         Modifies verbosity of download, where higher numbers mean more updates.

--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -157,7 +157,8 @@
             "checksum": "256b2ff5d7ad929d83d89bbe5a02f00d",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -176,7 +177,8 @@
             "checksum": "be946d5d276a672635a4d68c2b331f57",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -195,7 +197,8 @@
             "checksum": "2b6bed22f2879f11d0744f3434de3ad8",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -214,7 +217,8 @@
             "checksum": "af1c8628f2c76dfbb590294daeccb84f",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -233,7 +237,8 @@
             "checksum": "7f0f2aa3d4132d7365e3cf12e3d3c0df",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -252,7 +257,8 @@
             "checksum": "5d1284e2a9e3401ac82c3f1c425cffb1",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -271,7 +277,8 @@
             "checksum": "7ccea5d10ff4421b88ce859159039057",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -290,7 +297,8 @@
             "checksum": "a9195d94a8ae80b617bd232ac890f17d",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -309,7 +317,8 @@
             "checksum": "23429b45d7926882537ac531e799b422",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -328,7 +337,8 @@
             "checksum": "d0e8c7ad747afafa3c56329c503b6ebe",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -347,7 +357,8 @@
             "checksum": "c703674179b5656f7a020e5f21af54b6",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -366,7 +377,8 @@
             "checksum": "7f32b5c0f1e51d0a225e61c6ad7a7293",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -386,7 +398,8 @@
             "checksum": "7f6709b5a95206d4d78a9189605fdb1f",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -406,7 +419,8 @@
             "checksum": "3b8d92a5b94e8d04c4c47da85652eb46",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -426,7 +440,8 @@
             "checksum": "32e0f0b14421f2f5654ba72d00c7292e",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -446,7 +461,8 @@
             "checksum": "a54083189af1cd53a860b4e21aa61fa1",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -466,7 +482,8 @@
             "checksum": "5db3b83f8d64c55db702cea003eced8f",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -486,7 +503,8 @@
             "checksum": "c6559a3eb807ac95e99905ebdcc7dbdd",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -506,7 +524,8 @@
             "checksum": "578c8c77bfd9a63e31082e3366f3fbc9",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -526,7 +545,8 @@
             "checksum": "9ac80aa74dfaf037f26fa9c040c0a4e8",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -546,7 +566,8 @@
             "checksum": "5bbd3f00d3140a965c489bd631b35f7c",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -566,7 +587,8 @@
             "checksum": "b235df678c8578221947c39e0c5d35f4",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -586,7 +608,8 @@
             "checksum": "6625037636732c489a004627957512c4",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -606,7 +629,8 @@
             "checksum": "ca5c487f9031b8bf25cb720b5e2ebf29",
             "title": null,
             "tags": [
-                "functional", "MEG"
+                "functional",
+                "MEG"
             ],
             "redir": null,
             "url": [
@@ -626,7 +650,8 @@
             "checksum": "d633cbfe37fec25ed428d16f35780652",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -646,7 +671,8 @@
             "checksum": "0d7e844ee6a74d64e48e0a72a8a83291",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -666,7 +692,8 @@
             "checksum": "c4cfeae8608f570ecfee6f5ccc995e13",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -686,7 +713,8 @@
             "checksum": "1bdc330c2e87cb06766dbe5dac8ee043",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -705,7 +733,8 @@
             "checksum": "b035fdeb7c986fe5ab6be444d6492cf2",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -725,7 +754,8 @@
             "checksum": "94c3cd92b4ceca3c0fd1568a531ef2ad",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -745,7 +775,8 @@
             "checksum": "73879ae1806f48d03bea2c1ff1e14ea6",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -764,7 +795,8 @@
             "checksum": "5a30f4cb0a4daae3830afcd290cd383b",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -783,7 +815,8 @@
             "checksum": "e57031b5761f448fb667eba0557234de",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -802,7 +835,8 @@
             "checksum": "3bceb339f11b6b259509fdbf76d97db5",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -821,7 +855,8 @@
             "checksum": "d72c07ad574b195983eb119163ff93f7",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -841,7 +876,9 @@
             "checksum": "f3ef7c4601a4e8f44cafc59afb8aaa30",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -861,7 +898,9 @@
             "checksum": "463b8be657529800fd41ea3fc418c363",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -881,7 +920,9 @@
             "checksum": "837c8e7aa719495b0fb5a07645b23983",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -901,7 +942,9 @@
             "checksum": "1b1334761da62401f5519753500a49b0",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -921,7 +964,9 @@
             "checksum": "f6f3264ff311c4d629ffdb7d499f7a76",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -941,7 +986,9 @@
             "checksum": "946d6c41a5cc46c7391323778fb580db",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -961,7 +1008,9 @@
             "checksum": "19b3a5d41e991edfbaf5ba6639670170",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -981,7 +1030,9 @@
             "checksum": "1d675f6bacb94dc2d5b14f0381837cf0",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1001,7 +1052,9 @@
             "checksum": "608d60276eebccafd47ab6277be9601c",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1021,7 +1074,9 @@
             "checksum": "7029a8ba95fb7df0f9c6d88afed3d842",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1041,7 +1096,9 @@
             "checksum": "4335bbd73eed786bbdcd5888dca9edce",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1061,7 +1118,9 @@
             "checksum": "cf0e2e94ba7a29e11277aa63990dfc89",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1081,7 +1140,9 @@
             "checksum": "d2bbcc4162774cf8ec8fb5355f72a3bf",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1101,7 +1162,9 @@
             "checksum": "895187a70f8e2a8b194be91f0b1590a5",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1121,7 +1184,9 @@
             "checksum": "f357c7145a4363c087ebadaa4b92bfbb",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1141,7 +1206,9 @@
             "checksum": "4a835ce339d010064beddcb89fec43b5",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1161,7 +1228,9 @@
             "checksum": "cab550d9eea2e1636eb6974bb4689271",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1181,7 +1250,9 @@
             "checksum": "d539c68735f42c2ce70eda0dfb0c714c",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1201,7 +1272,9 @@
             "checksum": "755b9d61162091dbaa5a15de3dec6c02",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1221,7 +1294,9 @@
             "checksum": "fcb889621c85b6871ac275d3d0d2773c",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1241,7 +1316,9 @@
             "checksum": "e60d1b8bb942982120959754073f2248",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1261,7 +1338,9 @@
             "checksum": "250e34aabb02a03686306063be549e89",
             "title": null,
             "tags": [
-                "functional", "MRI", "fMRI"
+                "functional",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1280,7 +1359,11 @@
             "checksum": "bb6c53f7ef91c61bb597c7eaf5e4b076",
             "title": null,
             "tags": [
-                "functional", "structural", "meta-analysis", "MRI", "fMRI"
+                "functional",
+                "structural",
+                "meta-analysis",
+                "MRI",
+                "fMRI"
             ],
             "redir": null,
             "url": [
@@ -1299,7 +1382,8 @@
             "checksum": "e4eab79ed371d7362741f66bb44388d8",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1319,7 +1403,8 @@
             "checksum": "0962f6e9e9947ee2f34262543e5d3668",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1339,7 +1424,8 @@
             "checksum": "e6c2b2501139529c65c99b0bb8fe1fe8",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1359,7 +1445,8 @@
             "checksum": "337b0ce11b94f16b4bc75b257e96f32e",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1379,7 +1466,8 @@
             "checksum": "2ad821ab3825457cb17c727af2525d57",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1399,7 +1487,8 @@
             "checksum": "a3b7aaf1d185f0d6b632ad7f87ad1dce",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1419,7 +1508,8 @@
             "checksum": "c68e02d4a68cd064bd00e6ba8e265219",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1439,7 +1529,8 @@
             "checksum": "0f427e8f30382f5db7f267a82bb1d92c",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1459,7 +1550,8 @@
             "checksum": "ee06cb63b4c21ef661b7d86689bb59ab",
             "title": null,
             "tags": [
-                "functional", "MRI"
+                "functional",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1479,7 +1571,8 @@
             "checksum": "3236ded1f3db516ef1d31a90b3524e9f",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1499,7 +1592,8 @@
             "checksum": "b57d2cff0c0e80cf9d65acb2bf7cbb26",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1519,7 +1613,8 @@
             "checksum": "dfb3b4e1b73a619f2cd26c303c770d54",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1539,7 +1634,8 @@
             "checksum": "3d71892b49874ae253435223ee6a9503",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1559,7 +1655,8 @@
             "checksum": "5385cc40294f5165d7324347a7301f02",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1579,7 +1676,8 @@
             "checksum": "3ba8aff22ebf26340f4aa8267777bfb3",
             "title": null,
             "tags": [
-                "structural", "MRI"
+                "structural",
+                "MRI"
             ],
             "redir": null,
             "url": [
@@ -1598,7 +1696,8 @@
             "checksum": "cbcc614dd6bcfdcb19cddab59379223e",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1617,7 +1716,8 @@
             "checksum": "965011c681b616bc92754677f2317c0c",
             "title": null,
             "tags": [
-                "functional", "ASL"
+                "functional",
+                "ASL"
             ],
             "redir": null,
             "url": [
@@ -1636,7 +1736,8 @@
             "checksum": "15ef500ca7cf70171e45418f1bb459f3",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1655,7 +1756,8 @@
             "checksum": "cdd056d42721049b3a9fbb2f5c4abe1e",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1674,7 +1776,8 @@
             "checksum": "84cebc02d6418dc66f428463b2f0e279",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1693,7 +1796,8 @@
             "checksum": "658e3db053b283c13dca122f803f2464",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1712,7 +1816,8 @@
             "checksum": "ae03fe0f0071a2e6223218d0f9ba2775",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1731,7 +1836,8 @@
             "checksum": "15ee182fc5f1a1cfc332667a13970bd0",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1750,7 +1856,8 @@
             "checksum": "9789d43eefd33ce410b77da041dd0ad6",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [
@@ -1769,7 +1876,8 @@
             "checksum": "4041b17d30bad447baa6382d977fb7bd",
             "title": null,
             "tags": [
-                "receptors", "PET"
+                "receptors",
+                "PET"
             ],
             "redir": null,
             "url": [

--- a/neuromaps/datasets/tests/test_utils.py
+++ b/neuromaps/datasets/tests/test_utils.py
@@ -25,14 +25,14 @@ def test_get_data_dir():
 
 
 def test__get_token():
-    orig = os.environ.pop('neuromaps_OSF_TOKEN', None)
+    orig = os.environ.pop('NEUROMAPS_OSF_TOKEN', None)
     assert utils._get_token(None) is None
     assert utils._get_token('test') == 'test'
-    os.environ['neuromaps_OSF_TOKEN'] = 'test_env'
+    os.environ['NEUROMAPS_OSF_TOKEN'] = 'test_env'
     assert utils._get_token(None) == 'test_env'
     assert utils._get_token('test') == 'test'
     if orig is not None:  # reset env variable
-        os.environ['neuromaps_OSF_TOKEN'] = orig
+        os.environ['NEUROMAPS_OSF_TOKEN'] = orig
 
 
 @pytest.mark.xfail

--- a/neuromaps/datasets/utils.py
+++ b/neuromaps/datasets/utils.py
@@ -96,7 +96,7 @@ def get_data_dir(data_dir=None):
     ----------
     data_dir : str, optional
         Path to use as data directory. If not specified, will check for
-        environmental variable 'neuromaps_DATA'; if that is not set, will
+        environmental variable 'NEUROMAPS_DATA'; if that is not set, will
         use `~/neuromaps-data` instead. Default: None
 
     Returns
@@ -106,7 +106,7 @@ def get_data_dir(data_dir=None):
     """
 
     if data_dir is None:
-        data_dir = os.environ.get('neuromaps_DATA',
+        data_dir = os.environ.get('NEUROMAPS_DATA',
                                   os.path.join('~', 'neuromaps-data'))
     data_dir = os.path.expanduser(data_dir)
     if not os.path.exists(data_dir):
@@ -123,7 +123,7 @@ def _get_token(token=None):
     ----------
     token : str, optional
         OSF personal access token for accessing restricted annotations. Will
-        also check the environmental variable 'neuromaps_OSF_TOKEN' if not
+        also check the environmental variable 'NEUROMAPS_OSF_TOKEN' if not
         provided; if that is not set no token will be provided and restricted
         annotations will be inaccessible. Default: None
 
@@ -134,7 +134,7 @@ def _get_token(token=None):
     """
 
     if token is None:
-        token = os.environ.get('neuromaps_OSF_TOKEN', None)
+        token = os.environ.get('NEUROMAPS_OSF_TOKEN', None)
 
     return token
 
@@ -147,7 +147,7 @@ def _get_session(token=None):
     ----------
     token : str, optional
         OSF personal access token for accessing restricted annotations. Will
-        also check the environmental variable 'neuromaps_OSF_TOKEN' if not
+        also check the environmental variable 'NEUROMAPS_OSF_TOKEN' if not
         provided; if that is not set no token will be provided and restricted
         annotations will be inaccessible. Default: None
 


### PR DESCRIPTION
Screwed up OSF token env variable name when migrating repository.

Also, fixes to `osf.json` tag formatting and other minor changes to `neuromaps.datasets._osf` functions for internal use.