### PR TITLE
[MNT] Add issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/brain-map-request.yml
+++ b/.github/ISSUE_TEMPLATE/brain-map-request.yml
@@ -1,0 +1,50 @@
+name: New brain map
+description: Request to add brain map
+title: "[ENH] Request to add brain map: "
+labels: [enhancement]
+body:
+- type: markdown
+  attributes:
+    value: "Welcome to `neuromaps`! We're always happy to add new brain maps to our project. Please fill out the information below and one of the maintainers will get back to you with any questions."
+- type: checkboxes
+  id: owner
+  attributes:
+    label: Brain map source
+    description: "What is the source of the brain map(s) you want added to `neuromaps`?"
+    options:
+      - label: I am sharing a brain map that I created
+      - label: I am requesting a brain map be added from a published article
+- type: checkboxes
+  id: open-access
+  attributes:
+    label: Licensing
+    description: "The brain map(s) you are requesting to add to `neuromaps` will be made openly-available under a CC-BY license"
+    options:
+      - label: I have the necessary permissions to share these brain map(s) under a CC-BY license or they have already been made openly-available under a similar license
+        required: true
+- type: textarea
+  id: description
+  attributes:
+    label: Map description
+    description: "Please provide a brief description of the brain map here"
+    placeholder: "Where is the brain map from? What brain feature(s) does it describe?"
+- type: textarea
+  id: location
+  attributes:
+    label: Download location
+    description: "Where can we find a copy of the brain map(s)?"
+    placeholder: "Please include direct links!"
+- type: input
+  id: reference
+  attributes:
+    label: Reference DOI
+    description: "If there is ajournal article associated with this brain map, please include the DOI for the article here."
+    placeholder: "https://doi.org/XX"
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Code of Conduct
+    description: "By submitting this issue you agree to follow our [Code of Conduct](https://github.com/netneurolab/.github/blob/27712b33f41373c35206e3a87700a340aee18ac5/CODE_OF_CONDUCT.md)"
+    options:
+      - label: I agree to follow the `neuromaps` Code of Conduct
+        required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Submit a bug report
+title: "[BUG] "
+labels: [bug]
+body:
+- type: markdown
+  attributes:
+    value: "Welcome to `neuromaps`! Please fill out the following information describing the bug or issue you have encountered."
+- type: textarea
+  id: summary
+  attributes:
+    label: Issue summary
+    description: "Please provide a brief, 1-2 sentence overview of the issue."
+  validations:
+    required: true
+- type: textarea:
+  id: description
+  attributes:
+    label: Detailed issue description
+    description: "If more information is needed to describe your issue, please provide that here."
+- type: textarea
+  id: reproduction
+  attributes:
+    label: Steps to reproduce issue
+    description: "Please describe steps that can be taken to reproduce your issue."
+    value: |
+      1.
+      2.
+      3.
+      ...
+    render: python
+  validations:
+    required: true
+- type: input
+  id: version
+  attributes:
+    label: Software version
+    description: "What version of `neuromaps` are you using? (If you are unsure you can run `python -c 'import neuromaps; print(neuromaps.__version__)'`"
+- type: checkboxes
+  id: os
+  attributes:
+    label: "What operating system did you encounter this issue on?"
+    description: You may select more than one.
+    options:
+      - label: macOS
+      - label: Windows
+      - label: Linux
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Code of Conduct
+    description: "By submitting this issue you agree to follow our [Code of Conduct](https://github.com/netneurolab/.github/blob/27712b33f41373c35206e3a87700a340aee18ac5/CODE_OF_CONDUCT.md)."
+    options:
+      - label: I agree to follow the `neuromaps` Code of Conduct
+        required: true

--- a/.github/ISSUE_TEMPLATE/issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/issue-template.yml
@@ -1,0 +1,20 @@
+name: Issue template
+description: Submit an issue
+title: " "
+body:
+- type: markdown
+  attributes:
+    value: "Welcome to `neuromaps`! Please fill out the following information."
+- type: textarea:
+  id: description
+  attributes:
+    label: Description of issue
+    description: "Please use this space to describe the issue using as much detail as needed."
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Code of Conduct
+    description: "By submitting this issue you agree to follow our [Code of Conduct](https://github.com/netneurolab/.github/blob/27712b33f41373c35206e3a87700a340aee18ac5/CODE_OF_CONDUCT.md)."
+    options:
+      - label: I agree to follow the `neuromaps` Code of Conduct
+        required: true


### PR DESCRIPTION
Adds template forms for bug reports, new brain map requests, and generic issues.

I don't know if these will work but I guess we'll see :man_shrugging: 