### PR TITLE
[FIX] Fixes handling of volumetric maps for null models

### DIFF
--- a/neuromaps/nulls/__init__.py
+++ b/neuromaps/nulls/__init__.py
@@ -8,6 +8,6 @@ __all__ = [
 ]
 
 from neuromaps.nulls.nulls import (
-    naive_nonparametric, alexander_bloch, vazquez_rodriguez, vasa,
-    hungarian, baum, cornblath, burt2018, burt2020, moran
+    alexander_bloch, vazquez_rodriguez, vasa, hungarian, baum, cornblath,
+    burt2018, burt2020, moran
 )

--- a/neuromaps/nulls/nulls.py
+++ b/neuromaps/nulls/nulls.py
@@ -93,50 +93,6 @@ nulls : np.ndarray
 )
 
 
-def naive_nonparametric(data, atlas='fsaverage', density='10k',
-                        parcellation=None, n_perm=1000, seed=None, spins=None,
-                        surfaces=None):
-    rs = check_random_state(seed)
-    if spins is None:
-        if data is None:
-            if surfaces is None:
-                surfaces = fetch_atlas(atlas, density)['sphere']
-            coords, _ = get_parcel_centroids(surfaces,
-                                             parcellation=parcellation,
-                                             method='surface')
-        else:
-            coords = np.asarray(data)
-        spins = np.column_stack([
-            rs.permutation(len(coords)) for _ in range(n_perm)
-        ])
-    spins = load_spins(spins)
-    if data is None:
-        data = np.arange(len(spins))
-    return np.asarray(data)[spins]
-
-
-naive_nonparametric.__doc__ = """\
-Generates null maps from `data` using naive non-parametric method
-
-Method uses random permutations of `data` with no consideration for spatial
-topology to generate null distribution
-
-Parameters
-----------
-{data_or_none}
-{atlas_density}
-{parcellation}
-{n_perm}
-{seed}
-{spins}
-{surfaces}
-
-Returns
--------
-{nulls}
-""".format(**_nulls_input_docs)
-
-
 def alexander_bloch(data, atlas='fsaverage', density='10k', parcellation=None,
                     n_perm=1000, seed=None, spins=None, surfaces=None):
     if spins is None:
@@ -149,7 +105,7 @@ def alexander_bloch(data, atlas='fsaverage', density='10k', parcellation=None,
     spins = load_spins(spins)
     if data is None:
         data = np.arange(len(spins))
-    return np.asarray(data)[spins]
+    return load_data(data)[spins]
 
 
 alexander_bloch.__doc__ = """\

--- a/neuromaps/nulls/nulls.py
+++ b/neuromaps/nulls/nulls.py
@@ -4,6 +4,7 @@ Contains functionality for running spatial null models
 """
 
 import numpy as np
+from sklearn.utils.validation import check_random_state
 
 try:
     from brainsmash.mapgen import Base, Sampled
@@ -15,7 +16,6 @@ try:
     _brainspace_avail = True
 except ImportError:
     _brainspace_avail = False
-from sklearn.utils.validation import check_random_state
 
 from neuromaps.datasets import fetch_atlas
 from neuromaps.images import load_gifti, PARCIGNORE
@@ -504,10 +504,6 @@ Returns
 
 def burt2018(data, atlas='fsaverage', density='10k', parcellation=None,
              n_perm=1000, seed=None, distmat=None, n_proc=1, **kwargs):
-    if not _brainsmash_avail:
-        raise ImportError('Cannot run burt2018 null model when `brainsmash` '
-                          'is not installed. Please `pip install brainsmash` '
-                          'and try again.')
     return _make_surrogates(data, 'burt2018', atlas=atlas, density=density,
                             parcellation=parcellation, n_perm=n_perm,
                             seed=seed, n_proc=n_proc, distmat=distmat,

--- a/neuromaps/nulls/tests/test_nulls.py
+++ b/neuromaps/nulls/tests/test_nulls.py
@@ -3,21 +3,7 @@
 For testing neuromaps.nulls.nulls functionality
 """
 
-import numpy as np
 import pytest
-
-from neuromaps.nulls import nulls
-
-
-def test_naive_nonparametric():
-    data = np.random.rand(50)
-    perms = nulls.naive_nonparametric(data, n_perm=100)
-    assert perms.shape == (50, 100)
-    assert np.all(np.sort(perms, axis=0) == np.sort(data, axis=0)[:, None])
-
-    resamples = nulls.naive_nonparametric(None, n_perm=100)
-    assert resamples.shape == (20484, 100)
-    assert np.all(np.sort(resamples, axis=0) == np.arange(20484)[:, None])
 
 
 @pytest.mark.xfail

--- a/neuromaps/transforms.py
+++ b/neuromaps/transforms.py
@@ -200,11 +200,10 @@ def mni152_to_mni152(img, target='1mm', method='linear'):
         Resampled input `img`
     """
 
-    if target not in DENSITIES['MNI152']:
-        out = nimage.resample_to_img(img, target, interpolation=method)
-    else:
-        res = int(target[0])
-        out = nimage.resample_img(img, np.eye(3) * res, interpolation=method)
+    if target in DENSITIES['MNI152']:
+        target = fetch_atlas('MNI152', target)['T1w']
+
+    out = nimage.resample_to_img(img, target, interpolation=method)
 
     return out
 


### PR DESCRIPTION
A first pass towards being able to generate null maps for volumetric images. The primary issue I'm running into here is that this is computationally...I don't wanna say _impossible_, but basically impossible. If you're working with 1mm isotropic data in MNI152, by default you've got upwards of 1.8 million voxels. The distance matrix ends up being *many* terabytes :grimacing: 

Will consider ways around this... Potentially thresholding the distance matrix based on a KNN regime, where users supply the desired K as a distance (i.e., "10mm")?