### PR TITLE
[ENH] New versions of MNI1521mm and MNI1522mm

### DIFF
--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -79,16 +79,16 @@
         "1mm": {
             "url": [
                 "4mw3a",
-                "60b684be9096b7021c63d9e2"
+                "61eaf5091986f00160e3bd69"
             ],
-            "md5": "af9f6ef767af819899394e5cfdc5e155"
+            "md5": "7e8a7c8cb40afaeee429c1a13f099669"
         },
         "2mm": {
             "url": [
                 "4mw3a",
                 "60b684bd3a6df1021cd4e983"
             ],
-            "md5": "e2cd04cda23f1ca136100b92a9fd5e8f"
+            "md5": "bd7fe3a534001e94149192c4861c2bd3"
         },
         "3mm": {
             "url": [


### PR DESCRIPTION
I uploaded new versions of the MNI1521mm.tar.gz and MNI1522mm.tar.gz. Those new files contain 6Asym versions of the T1w brain map and of the brainmask. I updated the osf.json with the new md5 key.

IMPORTANT: I unintentionally deleted the old version of the MNI1521mm file, which means that old versions of the toolbox won't be able to fetch the 1mm atlases. We should therefore try to release a new version of the toolbox ASAP. 