### PR TITLE
Fix spatial null maps for volumetric data

### DIFF
--- a/neuromaps/datasets/atlases.py
+++ b/neuromaps/datasets/atlases.py
@@ -91,25 +91,16 @@ def _fetch_atlas(atlas, density, keys, url=None, data_dir=None, verbose=1):
     }
 
     if atlas == 'MNI152':
-        if density == '1mm' or density == '2mm':
-            filenames = [
-                f'tpl-MNI152NLin{version}_res-{density}{suff}.nii.gz'
-                for version, suff in (['2009cAsym', '_T1w'],
-                                      ['2009cAsym', '_T2w'],
-                                      ['2009cAsym', '_PD'],
-                                      ['2009cAsym', '_desc-brain_mask'],
-                                      ['2009cAsym', '_label-csf_probseg'],
-                                      ['2009cAsym', '_label-gm_probseg'],
-                                      ['2009cAsym', '_label-wm_probseg'],
-                                      ['6Asym', '_T1w'],
-                                      ['6Asym', '_desc-brain_mask'])
-            ]
-        elif density == '3mm':
-            filenames = [
-                f'tpl-MNI152NLin2009cAsym_res-{density}{suff}.nii.gz'
-                for suff in ('_T1w', '_T2w', '_PD', '_desc-brain_mask',
-                             '_label-csf_probseg', '_label-gm_probseg',
-                             '_label-wm_probseg')
+        filenames = [
+            f'tpl-MNI152NLin2009cAsym_res-{density}{suff}.nii.gz'
+            for suff in ('_T1w', '_T2w', '_PD', '_desc-brain_mask',
+                         '_label-csf_probseg', '_label-gm_probseg',
+                         '_label-wm_probseg')
+        ]
+        if density in ('1mm', '2mm'):
+            filenames += [
+                f'tpl-MNI152NLin6Asym_res-{density}{suff}.nii.gz'
+                for suff in ('_T1w', '_desc-brain_mask')
             ]
 
     else:

--- a/neuromaps/datasets/atlases.py
+++ b/neuromaps/datasets/atlases.py
@@ -91,12 +91,27 @@ def _fetch_atlas(atlas, density, keys, url=None, data_dir=None, verbose=1):
     }
 
     if atlas == 'MNI152':
-        filenames = [
-            f'tpl-MNI152NLin2009cAsym_res-{density}{suff}.nii.gz'
-            for suff in ('_T1w', '_T2w', '_PD', '_desc-brain_mask',
-                         '_label-csf_probseg', '_label-gm_probseg',
-                         '_label-wm_probseg')
-        ]
+        if density == '1mm' or density == '2mm':
+            filenames = [
+                f'tpl-MNI152NLin{version}_res-{density}{suff}.nii.gz'
+                for version, suff in (['2009cAsym', '_T1w'],
+                                      ['2009cAsym', '_T2w'],
+                                      ['2009cAsym', '_PD'],
+                                      ['2009cAsym', '_desc-brain_mask'],
+                                      ['2009cAsym', '_label-csf_probseg'],
+                                      ['2009cAsym', '_label-gm_probseg'],
+                                      ['2009cAsym', '_label-wm_probseg'],
+                                      ['6Asym', '_T1w'],
+                                      ['6Asym', '_desc-brain_mask'])
+            ]
+        elif density == '3mm':
+            filenames = [
+                f'tpl-MNI152NLin2009cAsym_res-{density}{suff}.nii.gz'
+                for suff in ('_T1w', '_T2w', '_PD', '_desc-brain_mask',
+                             '_label-csf_probseg', '_label-gm_probseg',
+                             '_label-wm_probseg')
+            ]
+
     else:
         filenames = [
             'tpl-{}_den-{}_hemi-{}_{}.surf.gii'
@@ -198,7 +213,14 @@ Returns
 
 
 def fetch_mni152(density='1mm', url=None, data_dir=None, verbose=1):
-    keys = ['T1w', 'T2w', 'PD', 'brainmask', 'CSF', 'GM', 'WM']
+    if density == '1mm' or density == '2mm':
+        keys = ['2009cAsym_T1w', '2009cAsym_T2w', '2009cAsym_PD',
+                '2009cAsym_brainmask', '2009cAsym_CSF', '2009cAsym_GM',
+                '2009cAsym_WM', '6Asym_T1w', '6Asym_brainmask']
+    elif density == '3mm':
+        keys = ['2009cAsym_T1w', '2009cAsym_T2w', '2009cAsym_PD',
+                '2009cAsym_brainmask', '2009cAsym_CSF', '2009cAsym_GM',
+                '2009cAsym_WM']
     return _fetch_atlas(
         'MNI152', density, keys, url=url, data_dir=data_dir, verbose=verbose
     )

--- a/neuromaps/datasets/atlases.py
+++ b/neuromaps/datasets/atlases.py
@@ -213,14 +213,11 @@ Returns
 
 
 def fetch_mni152(density='1mm', url=None, data_dir=None, verbose=1):
-    if density == '1mm' or density == '2mm':
-        keys = ['2009cAsym_T1w', '2009cAsym_T2w', '2009cAsym_PD',
-                '2009cAsym_brainmask', '2009cAsym_CSF', '2009cAsym_GM',
-                '2009cAsym_WM', '6Asym_T1w', '6Asym_brainmask']
-    elif density == '3mm':
-        keys = ['2009cAsym_T1w', '2009cAsym_T2w', '2009cAsym_PD',
-                '2009cAsym_brainmask', '2009cAsym_CSF', '2009cAsym_GM',
-                '2009cAsym_WM']
+    keys = ['2009cAsym_T1w', '2009cAsym_T2w', '2009cAsym_PD',
+            '2009cAsym_brainmask', '2009cAsym_CSF', '2009cAsym_GM',
+            '2009cAsym_WM']
+    if density in ('1mm', '2mm'):
+        keys += ['6Asym_T1w', '6Asym_brainmask']
     return _fetch_atlas(
         'MNI152', density, keys, url=url, data_dir=data_dir, verbose=verbose
     )

--- a/neuromaps/nulls/nulls.py
+++ b/neuromaps/nulls/nulls.py
@@ -47,9 +47,9 @@ data : (N,) array_like
 """,
     data_alexander_bloch="""\
 data : array_like or tuple-of-str or PathLike or nib.GiftiImage
-    Input data from which to generate null maps. If a parcellation is
-    provided, the data must be parcellated. If None is provided then
-    the resampling array will be returned instead.\
+    Input data from which to generate null maps. If None is provided then
+    the resampling array will be returned instead. If a parcellation is
+    provided, the data must be parcellated.\
 """,
     data="""\
 data : array_like or str or os.PathLike or niimg_like or tuple

--- a/neuromaps/nulls/nulls.py
+++ b/neuromaps/nulls/nulls.py
@@ -36,27 +36,25 @@ HEMI = dict(left='L', lh='L', right='R', rh='R')
 _nulls_input_docs = dict(
     data_or_none_parcel="""\
 data : (N,) array_like
-    Input data from which to generate null maps. The data should be already
-    parcellated with N being the number of parcels in the parcellation.
-    If None is provided then the resampling array will be returned instead.\
+    Input data from which to generate null maps. The data must be
+    parcellated. If None is provided then the resampling array will be returned
+    instead.\
 """,
     data_parcel="""\
 data : (N,) array_like
-    Input data from which to generate null maps. The data should be already
-    parcellated with N being the number of parcels in the parcellation.\
+    Input data from which to generate null maps. The data must be
+    parcellated.\
 """,
-    data_or_none="""\
-data : array_like or str or os.PathLike
+    data_alexander_bloch="""\
+data : array_like or tuple-of-str or PathLike or nib.GiftiImage
     Input data from which to generate null maps. If a parcellation is
-    provided, the data should already be parcellated. Otherwise, Filepaths to
-    the parcellation image should be provided. If None is provided then the
-    resampling array will be returned instead.\
+    provided, the data must be parcellated. If None is provided then
+    the resampling array will be returned instead.\
 """,
     data="""\
-data : array_like or str or os.PathLike
+data : array_like or str or os.PathLike or niimg_like or tuple
     Input data from which to generate null maps. If a parcellation is
-    provided, the data should already be parcellated. Otherwise, Filepaths to
-    the parcellation image should be provided. \
+    provided, the data must be parcellated.\
 """,
     atlas_density="""\
 atlas : {'fsLR', 'fsaverage', 'civet'}, optional
@@ -139,7 +137,7 @@ are projected to surface and parcels are reassigned based on minimum distances.
 
 Parameters
 ----------
-{data_or_none}
+{data_alexander_bloch}
 {atlas_density}
 {parcellation}
 {n_perm}

--- a/neuromaps/nulls/spins.py
+++ b/neuromaps/nulls/spins.py
@@ -8,7 +8,10 @@ import warnings
 
 import numpy as np
 from scipy import optimize, spatial
-from scipy.ndimage.measurements import _stats, labeled_comprehension
+try:  # scipy >= 1.8.0
+    from scipy.ndimage._measurements import _stats, labeled_comprehension
+except ImportError:  # scipy < 1.8.0
+    from scipy.ndimage.measurements import _stats, labeled_comprehension
 from sklearn.utils.validation import check_random_state
 
 from neuromaps.images import load_gifti, PARCIGNORE

--- a/neuromaps/stats.py
+++ b/neuromaps/stats.py
@@ -7,7 +7,10 @@ from functools import partial
 
 import numpy as np
 from scipy import special, stats as sstats
-from scipy.stats.stats import _chk2_asarray
+try:
+    from scipy.stats._stats_py import _chk2_asarray  # scipy >= 1.8.0
+except ImportError:
+    from scipy.stats.stats import _chk2_asarray  # scipy < 1.8.0
 from sklearn.utils.validation import check_random_state
 
 from neuromaps.images import load_data

--- a/neuromaps/transforms.py
+++ b/neuromaps/transforms.py
@@ -258,7 +258,7 @@ def mni152_to_mni152(img, target='1mm', method='linear'):
     """
 
     if target in DENSITIES['MNI152']:
-        target = fetch_atlas('MNI152', target)['T1w']
+        target = str(fetch_atlas('MNI152', target)['2009cAsym_T1w'])
 
     out = nimage.resample_to_img(img, target, interpolation=method)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nilearn
 numpy>=1.14.0
 scikit-learn
 scipy>=0.17
+packaging


### PR DESCRIPTION
This pull request fixes the bugs reported in Issue #27, as well as a few other unreported bugs. The main changes are:

- Added a try-except statement to clean-up temporary files when an error is raised in _vol_surrogates() function.

- WindowsPath object fetched using fetch_atlas() is now converted to a str in the mni152_to_mni152() function. This fixes an Error happening when load_niimg(), a nibabel function, is called.

- In the _make_surrogates() function, when genfunc() is called as _vol_surrogates(), an error was raised because n_proc is not a valid argument. The function call was modified so that n_proc is now a keyword argument.

- The function call to genfunc() in the _make_surrogates() function was modified so that n_proc is now a keyword argument. This fixes an issue happening when _vol_surrogates() is called.

- The generation of burt2020 nulls required version >= 0.10.0 of brainsmash. The burt2020() function now tests for that using the "packaging" module. This module has been added to the requirement.txt file.

- The _vol_surrogates() function was refactored such that the data is masked only when no parcellation is used. Otherwise, the data should already be parcellated. 

- The function now checks whether the data (if not parcellated) is in the 2009cASym or 6ASym MNI152 space. If it is in neither, the 2009cASym brainmask is resampled behind the scene to fit the data.

- Fixed a bug in _vol_surrogates() where the column average was not computed when using a parcellation. 

- Fixed a bug happening when the user try to generate a single null brainmap using the burt2018, burt2020 or moran method.

- Modified the fetch_atlas() function so that two different T1w and brain masks (one for 2009cAsym and one for 6Asym) are downloaded from OSF and added to the Bunch object when fetching the MNI152 atlases for the 1mm and 2mm densities. We also added the name of the MNI152 version as prefix to the map names in the Bunch object. For instance, "T1w" is now called "2009cAsym_T1w".

- Modified the documentation of null functions, clarifying the Types of the "data" parameter

- Added a check making sure that data is array-like and one dimensional when a parcellation is used in any of the burt2018(), burt2020() or moran() spatial nulls.