### PR TITLE
check input in stat.compare_images for parc data

### DIFF
--- a/neuromaps/stats.py
+++ b/neuromaps/stats.py
@@ -24,7 +24,7 @@ def compare_images(src, trg, metric='pearsonr', ignore_zero=True, nulls=None,
     Parameters
     ----------
     src, trg : str or os.PathLike or nib.GiftiImage or niimg_like or tuple
-        Images to be compared
+        Images or 1d np.array with same length (for parcellated data) to be compared
     metric : {'pearsonr', 'spearmanr', callable}, optional
         Type of similarity metric to use to compare `src` and `trg` images. If
         a callable function is provided it must accept two inputs and return a
@@ -57,7 +57,13 @@ def compare_images(src, trg, metric='pearsonr', ignore_zero=True, nulls=None,
                 raise ValueError('Provided callable `metric` must accept two '
                                  'inputs and return single value.')
 
-    srcdata, trgdata = load_data(src), load_data(trg)
+    if isinstance(src,np.ndarray)&isinstance(trg,np.ndarray):
+        if not src.shape[0]==trg.shape[0]:
+            raise ValueError('Parcellated data arrays should have the same length')
+        else:
+            srcdata, trgdata=src, trg
+    else:
+        srcdata, trgdata = load_data(src), load_data(trg)
 
     mask = np.zeros(len(srcdata), dtype=bool)
     if ignore_zero:


### PR DESCRIPTION
`stats.compare_images` is expecting image as src and trg and will not work for arrays (parcellated data).
I have been testing the destrieux example shown in the doc.
The src and trg were two arrays but I have no idea why `stats.compare_images` would work in this case.
When I tested Desikan, it gave

`corr, pval = stats.compare_images(neurosynth_parc, abagen_parc, nulls=rotated)
  File "/usr/local/lib/python3.9/site-packages/neuromaps/stats.py", line 60, in compare_images
    srcdata, trgdata = load_data(src), load_data(trg)`

So I made the changes to check if the scr and trg are np arrays with the same length then use them directly as the scrdata and trgdata.