### PR TITLE
[FIX] Fix unsupported path-like objects for mni152_to_mni152()

### DIFF
--- a/neuromaps/transforms.py
+++ b/neuromaps/transforms.py
@@ -258,9 +258,10 @@ def mni152_to_mni152(img, target='1mm', method='linear'):
     """
 
     if target in DENSITIES['MNI152']:
-        target = str(fetch_atlas('MNI152', target)['2009cAsym_T1w'])
+        target = fetch_atlas('MNI152', target)['2009cAsym_T1w']
 
-    out = nimage.resample_to_img(img, target, interpolation=method)
+    out = nimage.resample_to_img(load_nifti(img), load_nifti(target),
+                                 interpolation=method)
 
     return out
 


### PR DESCRIPTION
The function `mni152_to_mni152()` calls the nilearn function `resample_to_img()`, but this function calls `_utils.niimg.load_niimg()`, which currently does not support path-like objects (e.g. `pathlib.Path` objects). Calling this function using path-like objects currently results in a `TypeError`. I fixed this bug by calling `load_nifti()` on the img and target objects before calling `resample_to_img()` in the `mni152_to_mni152()` function.