### PR TITLE
[FIX] Fix bug in resample_images

### DIFF
--- a/neuromaps/resampling.py
+++ b/neuromaps/resampling.py
@@ -270,6 +270,8 @@ def resample_images(src, trg, src_space, trg_space, method='linear',
         func = globals()[resampling]
         src, trg = func(src, trg, src_space, trg_space, hemi=hemi,
                         method=method, **opts)
+        src, _ = zip(*transforms._check_hemi(src, hemi))
+        trg, _ = zip(*transforms._check_hemi(trg, hemi))
         src = tuple(load_gifti(s) for s in src)
         trg = tuple(load_gifti(t) for t in trg)
 

--- a/neuromaps/transforms.py
+++ b/neuromaps/transforms.py
@@ -267,14 +267,15 @@ def mni152_to_mni152(img, target='1mm', method='linear'):
 
 
 def _check_hemi(data, hemi):
-    """ Utility to check that `data` and `hemi` jibe
+    """
+    Utility to check that `data` and `hemi` jibe
 
     Parameters
     ----------
     data : str or os.PathLike or tuple
         Input data
     hemi : str
-        Hemisphere(s) corresponding to `data
+        Hemisphere(s) corresponding to `data`
 
     Returns
     -------


### PR DESCRIPTION
This PR fixes [Issue#24](https://github.com/netneurolab/neuromaps/issues/24): a bug in `resample_images` that would happen when a single str or os.PathLike object specifies the path to single-hemispheric `src` or `trg` images. This bug would happen when `resample_images`would try to load the gifti file of the un-transformed map. A call to the `tranforms._check_hemi` function fixes the issue.