### PR TITLE
[FIX] Fixed bug in inverse_transform function

### DIFF
--- a/neuromaps/parcellate.py
+++ b/neuromaps/parcellate.py
@@ -170,7 +170,7 @@ class Parcellater():
         """
 
         if not self._volumetric:
-            verts = parcels_to_vertices(data, self.parcellation, self.drop)
+            verts = parcels_to_vertices(data, self.parcellation)
             img = _array_to_gifti(verts)
         else:
             data = np.atleast_2d(data)


### PR DESCRIPTION
This PR fixes a bug in the `inverse_transform` function, which is discussed in [Issue#59](https://github.com/netneurolab/neuromaps/issues/59). As described, we fixed the issue by removing the self.drop argument from the function call to `parcel_to_vertices`.