### PR TITLE
[FIX] Update install_dependencies.sh to resolve wget dns failure

### DIFF
--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -23,8 +23,10 @@ if [ -n "${OPTIONAL_DEPENDS}" ]; then
     done
 fi
 
-wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 --no-dns-cache \
-    https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip
+while true; do
+    wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 --no-dns-cache -c \
+        https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip && break
+done
 unzip workbench-linux64-v1.5.0.zip -d "${HOME}"
 echo "${HOME}/workbench/bin_linux64" >> "${GITHUB_PATH}"
 

--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -23,7 +23,8 @@ if [ -n "${OPTIONAL_DEPENDS}" ]; then
     done
 fi
 
-wget https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip
+wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 --no-dns-cache \
+    https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip
 unzip workbench-linux64-v1.5.0.zip -d "${HOME}"
 echo "${HOME}/workbench/bin_linux64" >> "${GITHUB_PATH}"
 


### PR DESCRIPTION
Part failure due to dns resolve error. Not sure the root cause, tried 1) [this](https://github.com/actions/virtual-environments/issues/798) and 2) adding a random sleep, both did not work. Adding retry to wget seems to work. See [this link](https://superuser.com/questions/493640/how-to-retry-connections-with-wget) for parameter settings. Temporary patch.
