### PR TITLE
[ENH] new "ignore_background_data" parameter in Parcellater + other minor fixes

### DIFF
--- a/neuromaps/nulls/spins.py
+++ b/neuromaps/nulls/spins.py
@@ -551,12 +551,16 @@ def parcels_to_vertices(data, parcellation):
     return np.squeeze(projected)
 
 
-def vertices_to_parcels(data, parcellation):
+def vertices_to_parcels(data, parcellation, background=None):
     """
-    Reduces vertex-level `data` to parcels defined by `parcellation`
+    Reduces vertex-level `data` to parcels defined by `parcellation`.
 
-    Takes average of vertices within each parcel (excluding NaN values).
-    Assigns NaN to parcels for which *all* vertices are NaN.
+    Compute the average `data` within each parcel. This average ignores
+    vertices with background `data` values (e.g. medial wall) or with NaN
+    values.
+
+    Assigns NaN to parcels for which *all* vertices are background or NaN
+    values.
 
     Parameters
     ----------
@@ -564,14 +568,21 @@ def vertices_to_parcels(data, parcellation):
         Vertex-level data to be reduced to parcels
     parcellation : tuple-of-str or os.PathLike
         Filepaths to parcellation images to parcellate `data`
+    background: None or float
+        Specifies the background value to ignore when computing the averages.
+        If None, then only vertices with NaN values are ignored. Default: None
 
-    Reurns
+    Returns
     ------
     reduced : numpy.ndarray
         Parcellated `data`
     """
 
     data = np.vstack(data)
+
+    if background is not None:
+        data[data == background] = np.nan
+
     vertices = np.hstack([
         load_gifti(parc).agg_data() for parc in parcellation
     ])

--- a/neuromaps/plotting.py
+++ b/neuromaps/plotting.py
@@ -88,11 +88,10 @@ def plot_surf_template(data, template, density, surf='inflated',
 
     if not opts.get('colorbar', False):
         fig.tight_layout()
-
-    if n_surf == 1:
-        fig.subplots_adjust(wspace=-0.1)
-    else:
-        fig.subplots_adjust(wspace=-0.4, hspace=-0.15)
+        if n_surf == 1:
+            fig.subplots_adjust(wspace=-0.1)
+        else:
+            fig.subplots_adjust(wspace=-0.4, hspace=-0.15)
 
     return fig
 


### PR DESCRIPTION
This commit adds an `ignore_background_data` parameter and a `background_value` parameter in the `transform` method of the `Parcellater` class. These parameter are useful for when the image that we want to parcellate has background data values that should be ignored (see the discussion in Issue #66 as an example). This commit also fixes other minor bugs. The major changes are as follows:

spins.py:
- Added `background` parameter to `vertices_to_parcels` function.

parcellate.py:
- Added `ignore_background_data` and `background_value` parameter to the `transform` method of the `Parcellater` class. See their description in the docstring of the method for more information on how they work.

- Fixed a bug happening when using the `transform` method with volumetric maps and `resampling_target` of the `Parcellater` object set to `parcellation`: `NiftiLabelsMasker` was called with `resampling_target=self.resampling_target`, but this function does not accept `parcellation` as a valid resampling_target. Since the resampling happens earlier in the `transform` function, there's no need to resample the data in `NiftiLabelsMasker`, so `resampling_target` in `NiftiLabelsMasker` can be set to `None`.

- Fixed a bug happening when using the `transform` method of the `Parcellater` class with `resampling_target` set to `parcellation`: `resample_images` was always called with the `method` parameter set to `nearest`. The `nearest` method is however not appropriate when resampling a `data` image. The `method` parameter is now set to `linear` when the `data` image is resampled to the parcellation.

plotting.py:
- Fixed a bug in `plot_surf_template`:  the colorbar was wrongly placed when `colorbar` was set to `True`.