### PR TITLE
[FIX] Fix bugs in burt2018 and moran nulls

### DIFF
--- a/neuromaps/nulls/nulls.py
+++ b/neuromaps/nulls/nulls.py
@@ -531,6 +531,10 @@ def _make_surrogates(data, method, atlas='fsaverage', density='10k',
                                            parcellation, distmat,
                                            n_proc=n_proc):
         if method == 'burt2018':
+            if parcellation is None:
+                if hind is not None:
+                    hdist = np.take_along_axis(
+                        hdist, np.argsort(hind, axis=-1), axis=-1)
             hdata += np.abs(np.nanmin(darr)) + 0.1
             hsurr = batch_surrogates(hdist, hdata, n_surr=n_perm, seed=seed)
         elif method == 'burt2020':
@@ -552,12 +556,16 @@ def _make_surrogates(data, method, atlas='fsaverage', density='10k',
                 os.unlink(hind.filename)
                 del hdist, hind
         elif method == 'moran':
+            if parcellation is None:
+                if hind is not None:
+                    hdist = np.take_along_axis(
+                        hdist, np.argsort(hind, axis=-1), axis=-1)
             dist = hdist.astype('float64')
             np.fill_diagonal(dist, 1)
             dist **= -1
             opts = dict(joint=True, tol=1e-6, n_rep=n_perm, random_state=seed)
             opts.update(**kwargs)
-            mrs = MoranRandomization(**kwargs)
+            mrs = MoranRandomization(**opts)
             hsurr = mrs.fit(dist).randomize(hdata).T
 
         surrogates[hsl] = hsurr


### PR DESCRIPTION
This PR fixes bugs in `nulls.burt2018` and `nulls.moran` encountered when trying to generate surrogate brain maps with a volumetric surface and without parcellation: the `hdist` matrix, which stores the distance between each voxel in the image, was being returned sorted. This is required for the `nulls.burt2020` function, but not for `nulls.burt2018` nor `nulls.moran`. I fixed this bug by unsorting the distance matrices when we use these two functions with a volumetric surface and without parcellation. This is a *temporary fix* as sorting, then unsorting the distance matrix is quite innefficient.

I also fixed another bug that prevented us from passing `**kwargs` to the `nulls.moran` function.