### PR TITLE
[FIX] Fix order of hemispheres in beliveau and norgaard fsaverage maps

### DIFF
--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -231,27 +231,6 @@
             "desc": "az10419369",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "surface",
-            "fname": "source-beliveau2017_desc-az10419369_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "beliveau2017/az10419369/fsaverage/",
-            "checksum": "df01756cd50af0e9ebcc2c6df0405135",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "638543a2c86e2818da88f993"
-            ]
-        },
-        {
-            "source": "beliveau2017",
-            "desc": "az10419369",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "surface",
             "fname": "source-beliveau2017_desc-az10419369_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -266,6 +245,27 @@
             "url": [
                 "4mw3a",
                 "638543b0723a11190518c8a6"
+            ]
+        },
+        {
+            "source": "beliveau2017",
+            "desc": "az10419369",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "surface",
+            "fname": "source-beliveau2017_desc-az10419369_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "beliveau2017/az10419369/fsaverage/",
+            "checksum": "df01756cd50af0e9ebcc2c6df0405135",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "638543a2c86e2818da88f993"
             ]
         },
         {
@@ -293,27 +293,6 @@
             "desc": "cimbi36",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "surface",
-            "fname": "source-beliveau2017_desc-cimbi36_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "beliveau2017/cimbi36/fsaverage/",
-            "checksum": "d31200bc45b31953f6d8c3632b5d7044",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "638543cdc86e2818da88f9e7"
-            ]
-        },
-        {
-            "source": "beliveau2017",
-            "desc": "cimbi36",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "surface",
             "fname": "source-beliveau2017_desc-cimbi36_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -328,6 +307,27 @@
             "url": [
                 "4mw3a",
                 "638543bf228a5a18987bc2c1"
+            ]
+        },
+        {
+            "source": "beliveau2017",
+            "desc": "cimbi36",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "surface",
+            "fname": "source-beliveau2017_desc-cimbi36_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "beliveau2017/cimbi36/fsaverage/",
+            "checksum": "d31200bc45b31953f6d8c3632b5d7044",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "638543cdc86e2818da88f9e7"
             ]
         },
         {
@@ -355,27 +355,6 @@
             "desc": "cumi101",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "surface",
-            "fname": "source-beliveau2017_desc-cumi101_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "beliveau2017/cumi101/fsaverage/",
-            "checksum": "7b5bab02f7edbdc255b5c72c93189d4e",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "638543dbc86e2818d988f7ea"
-            ]
-        },
-        {
-            "source": "beliveau2017",
-            "desc": "cumi101",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "surface",
             "fname": "source-beliveau2017_desc-cumi101_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -390,6 +369,27 @@
             "url": [
                 "4mw3a",
                 "638543ea1daa6b183975935a"
+            ]
+        },
+        {
+            "source": "beliveau2017",
+            "desc": "cumi101",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "surface",
+            "fname": "source-beliveau2017_desc-cumi101_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "beliveau2017/cumi101/fsaverage/",
+            "checksum": "7b5bab02f7edbdc255b5c72c93189d4e",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "638543dbc86e2818d988f7ea"
             ]
         },
         {
@@ -417,27 +417,6 @@
             "desc": "dasb",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "surface",
-            "fname": "source-beliveau2017_desc-dasb_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "beliveau2017/dasb/fsaverage/",
-            "checksum": "e4921dcc6da907318ef47d7b15250b84",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "63854385c86e2818da88f94b"
-            ]
-        },
-        {
-            "source": "beliveau2017",
-            "desc": "dasb",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "surface",
             "fname": "source-beliveau2017_desc-dasb_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -452,6 +431,27 @@
             "url": [
                 "4mw3a",
                 "63854394228a5a18987bc26e"
+            ]
+        },
+        {
+            "source": "beliveau2017",
+            "desc": "dasb",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "surface",
+            "fname": "source-beliveau2017_desc-dasb_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "beliveau2017/dasb/fsaverage/",
+            "checksum": "e4921dcc6da907318ef47d7b15250b84",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "63854385c86e2818da88f94b"
             ]
         },
         {
@@ -479,27 +479,6 @@
             "desc": "sb207145",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "space",
-            "fname": "source-beliveau2017_desc-sb207145_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "beliveau2017/sb207145/fsaverage/",
-            "checksum": "4bb6b0f54f2cdf3b3dba9e63cf3daa8d",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "638542b2a98e5f1ac2103866"
-            ]
-        },
-        {
-            "source": "beliveau2017",
-            "desc": "sb207145",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "space",
             "fname": "source-beliveau2017_desc-sb207145_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -514,6 +493,27 @@
             "url": [
                 "4mw3a",
                 "638542c2c86e2818d588f461"
+            ]
+        },
+        {
+            "source": "beliveau2017",
+            "desc": "sb207145",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "space",
+            "fname": "source-beliveau2017_desc-sb207145_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "beliveau2017/sb207145/fsaverage/",
+            "checksum": "4bb6b0f54f2cdf3b3dba9e63cf3daa8d",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "638542b2a98e5f1ac2103866"
             ]
         },
         {
@@ -1767,27 +1767,6 @@
             "desc": "flumazenil",
             "space": "fsaverage",
             "den": "164k",
-            "hemi": "R",
-            "format": "surface",
-            "fname": "source-norgaard2021_desc-flumazenil_space-fsaverage_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "norgaard2021/flumazenil/fsaverage/",
-            "checksum": "4f711daa3327499295fb7e9b13552197",
-            "title": null,
-            "tags": [
-                "receptors",
-                "PET"
-            ],
-            "redir": null,
-            "url": [
-                "4mw3a",
-                "6385540d228a5a18d67bcadd"
-            ]
-        },
-        {
-            "source": "norgaard2021",
-            "desc": "flumazenil",
-            "space": "fsaverage",
-            "den": "164k",
             "hemi": "L",
             "format": "surface",
             "fname": "source-norgaard2021_desc-flumazenil_space-fsaverage_den-164k_hemi-L_feature.func.gii",
@@ -1802,6 +1781,27 @@
             "url": [
                 "4mw3a",
                 "638553fe228a5a18d67bcac8"
+            ]
+        },
+        {
+            "source": "norgaard2021",
+            "desc": "flumazenil",
+            "space": "fsaverage",
+            "den": "164k",
+            "hemi": "R",
+            "format": "surface",
+            "fname": "source-norgaard2021_desc-flumazenil_space-fsaverage_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "norgaard2021/flumazenil/fsaverage/",
+            "checksum": "4f711daa3327499295fb7e9b13552197",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "6385540d228a5a18d67bcadd"
             ]
         },
         {


### PR DESCRIPTION
I swapped the order for right and left annotation information in the osf.json file for beliveau2017 and norgaard2021 fsaverage maps. This does not change any data, it just changes the order in which R and L are fetched using neuromaps functionality. Now, when these maps are fetched, tuples will be ordered (L, R) instead of (R, L).