### PR TITLE
[FIX] Fixed URLs for annotation files

### DIFF
--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -1029,7 +1029,7 @@
             "redir": null,
             "url": [
                 "4mw3a",
-                "6130fe40ab8bca0225edc458"
+                "6130fe34af610c0217dfe61a"
             ]
         },
         {
@@ -1759,7 +1759,7 @@
             "redir": null,
             "url": [
                 "4mw3a",
-                "638553fe228a5a18d67bcac8"
+                "6385541b228a5a18da7bd628"
             ]
         },
         {


### PR DESCRIPTION
This PR fixes the URLs of two annotation files, which were accidently modified in previous pull requests. This commit fixes Issue #99