### PR TITLE
Filename update for CMRglc

### DIFF
--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -1857,7 +1857,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1878,7 +1879,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1899,7 +1901,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1920,7 +1923,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1941,7 +1945,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1962,7 +1967,8 @@
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1972,18 +1978,19 @@
         },
         {
             "source": "raichle",
-            "desc": "cmruglu",
+            "desc": "cmrglc",
             "space": "fsLR",
             "den": "164k",
             "hemi": "L",
             "format": "surface",
-            "fname": "source-raichle_desc-cmruglu_space-fsLR_den-164k_hemi-L_feature.func.gii",
-            "rel_path": "raichle/cmruglu/fsLR/",
+            "fname": "source-raichle_desc-cmrglc_space-fsLR_den-164k_hemi-L_feature.func.gii",
+            "rel_path": "raichle/cmrglc/fsLR/",
             "checksum": "0f427e8f30382f5db7f267a82bb1d92c",
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+                "metabolism"
             ],
             "redir": null,
             "url": [
@@ -1993,18 +2000,19 @@
         },
         {
             "source": "raichle",
-            "desc": "cmruglu",
+            "desc": "cmrglc",
             "space": "fsLR",
             "den": "164k",
             "hemi": "R",
             "format": "surface",
-            "fname": "source-raichle_desc-cmruglu_space-fsLR_den-164k_hemi-R_feature.func.gii",
-            "rel_path": "raichle/cmruglu/fsLR/",
+            "fname": "source-raichle_desc-cmrglc_space-fsLR_den-164k_hemi-R_feature.func.gii",
+            "rel_path": "raichle/cmrglc/fsLR/",
             "checksum": "ee06cb63b4c21ef661b7d86689bb59ab",
             "title": null,
             "tags": [
                 "functional",
-                "MRI"
+                "PET",
+		"metabolism"
             ],
             "redir": null,
             "url": [


### PR DESCRIPTION
Changed filename of the CMRglc PET data. It used to be `cmruglu` and is now `cmrglc` according to standard convention (see e.g. [Wikipedia](https://en.wikipedia.org/wiki/Glucose), or papers like [this one](https://doi.org/10.1097/00004647-199807000-00002)).

**IMPORTANT:** Before merging, we would need to update the folder and filename of CMRglc on [OSF](https://osf.io/4mw3a/) as well. It'd be awesome if someone with access to that repo could change it!

Also, changed tags in the raichle data from `MRI` to `PET` and added the tag `metabolism`.