### PR TITLE
[FIX] Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
This commit adds a `.readthedocs.yaml` files, to comply with the new readthedocs requirements (see [here](https://blog.readthedocs.com/migrate-configuration-v2/) for more details)