### PR TITLE
[FIX] raise error when parcellating volumetric data defined as array

### DIFF
--- a/neuromaps/parcellate.py
+++ b/neuromaps/parcellate.py
@@ -147,7 +147,14 @@ class Parcellater():
                              'hemisphere: {self.hemi}')
 
         if isinstance(data, np.ndarray):
-            data = _array_to_gifti(data)
+            if space == 'MNI152':
+                raise ValueError('Volumetric data to be parcellated should be '
+                                 'provided as a Nifti1Image with the correct '
+                                 'affine defined. You can use '
+                                 'nibabel.nifti1.Nifti1Image to construct a '
+                                 'Nifti1Image from your array.')
+            else:
+                data = _array_to_gifti(data)
         if self.resampling_target in ('data', None):
             resampling_method = 'nearest'
         else:


### PR DESCRIPTION
Input data to be parcellated can be array-like but the neuromaps Parcellater will assume it's surface data.
I've modified the code such that an error is thrown when MNI152 data is provided as an `np.ndarray`. Volumetric data should instead be provided as a Nifti1Image. We don't convert the array to a Nifti1Image because the affine should be defined too. This PR was prompted by issue #122 