### PR TITLE
[ENH] Add kappa-opioid receptor map

### DIFF
--- a/neuromaps/datasets/_osf.py
+++ b/neuromaps/datasets/_osf.py
@@ -13,7 +13,7 @@ from neuromaps.datasets.utils import _get_session
 
 # uniquely identify each item ('hemi' can be None)
 FNAME_KEYS = ['source', 'desc', 'space', 'den', 'res', 'hemi']
-# auto-generated (checksum can be None if file doest not exist)
+# auto-generated (checksum can be None if file doesn't not exist)
 AUTO_KEYS = ['format', 'fname', 'rel_path', 'checksum']
 # required keys but values are all optional
 COND_KEYS = ['title', 'tags', 'redir', 'url']

--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -2443,6 +2443,25 @@
             ]
         },
         {
+            "source": "vijay2018",
+            "desc": "ly2795050",
+            "space": "MNI152",
+            "res": "2mm",
+            "format": "volume",
+            "fname": "source-vijay2018_desc-ly2795050_space-MNI152_res-2mm_feature.nii.gz",
+            "rel_path": "vijay2018/ly2795050/MNI152",
+            "checksum": "a911d664d26daca6a53fa9d53234a5cf",
+            "title": null,
+            "tags": [
+                "receptors",
+                "PET"
+            ],
+            "redir": null,
+            "url": [
+                "4mw3a",
+                "6566590ea7a4834be871422b"]
+        },
+        {
             "source": "xu2020",
             "desc": "FChomology",
             "space": "fsLR",

--- a/neuromaps/stats.py
+++ b/neuromaps/stats.py
@@ -38,7 +38,7 @@ def compare_images(src, trg, metric='pearsonr', ignore_zero=True, nulls=None,
         `trg` data. Default: True
     nulls : array_like, optional
         Null data for `src` to use in generating a non-parametric p-value.
-        If not specified a parameteric p-value is generated. Default: None
+        If not specified a parametric p-value is generated. Default: None
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan. 'propagate' propagates
         the nan values to the callable metric (will return nan if the metric


### PR DESCRIPTION
Added new PET receptor map for kappa-opioid. This map comes from Vijay et al 2018 Neuropsychopharmacology (thanks to Evan D Morris and Jocelyn Hoye for sharing it with us!).