### PR TITLE
[FIX] Fix doc load_data

### DIFF
--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -132,8 +132,8 @@ def load_nifti(img):
     try:
         img = nib.load(img)
     except (TypeError) as err:
-        msg = ('stat: path should be string, bytes, os.PathLike or integer, '
-               'not Nifti1Image')
+        msg = ('expected str, bytes or os.PathLike '
+               'object, not Nifti1Image')
         if not str(err) == msg:
             raise err
     return img
@@ -165,8 +165,8 @@ def load_gifti(img):
                 img = nib.GiftiImage.from_bytes(gz.read())
         # it's not a pre-loaded GiftiImage so error out
         elif (isinstance(err, TypeError)
-              and not str(err) == 'stat: path should be string, bytes, os.'
-                                  'PathLike or integer, not GiftiImage'):
+              and not str(err) == 'expected str, bytes or os.PathLike '
+                                  'object, not GiftiImage'):
             raise err
 
     return img
@@ -202,8 +202,8 @@ def load_data(data):
     except (AttributeError, TypeError, ValueError, OSError) as err:
         # niimg_like or path_like (nifti)
         if (isinstance(err, AttributeError)
-            or str(err) == 'stat: path should be string, bytes, os.'
-                           'PathLike or integer, not Nifti1Image'):
+            or str(err) == 'expected str, bytes or os.PathLike '
+                           'object, not Nifti1Image'):
             out = np.stack([load_nifti(img).get_fdata() for img in data],
                            axis=3)
         # array_like (parcellated)

--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -205,7 +205,8 @@ def load_data(data):
             or (
                 "os.PathLike" in str(err) 
                 and "not Nifti1Image" in str(err)
-            ):
+                )
+           ):
             out = np.stack([load_nifti(img).get_fdata() for img in data],
                            axis=3)
         # array_like (parcellated)

--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -132,9 +132,7 @@ def load_nifti(img):
     try:
         img = nib.load(img)
     except (TypeError) as err:
-        msg = ('expected str, bytes or os.PathLike '
-               'object, not Nifti1Image')
-        if not str(err) == msg:
+        if not ("os.PathLike" in str(err) and "not Nifti1Image" in str(err)):
             raise err
     return img
 
@@ -165,8 +163,9 @@ def load_gifti(img):
                 img = nib.GiftiImage.from_bytes(gz.read())
         # it's not a pre-loaded GiftiImage so error out
         elif (isinstance(err, TypeError)
-              and not str(err) == 'expected str, bytes or os.PathLike '
-                                  'object, not GiftiImage'):
+              and not (
+                  "os.PathLike" in str(err) and "not GiftiImage" in str(err)
+              ):
             raise err
 
     return img
@@ -202,8 +201,10 @@ def load_data(data):
     except (AttributeError, TypeError, ValueError, OSError) as err:
         # niimg_like or path_like (nifti)
         if (isinstance(err, AttributeError)
-            or str(err) == 'expected str, bytes or os.PathLike '
-                           'object, not Nifti1Image'):
+            or (
+                "os.PathLike" in str(err) 
+                and "not Nifti1Image" in str(err)
+            ):
             out = np.stack([load_nifti(img).get_fdata() for img in data],
                            axis=3)
         # array_like (parcellated)

--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -165,6 +165,7 @@ def load_gifti(img):
         elif (isinstance(err, TypeError)
               and not (
                   "os.PathLike" in str(err) and "not GiftiImage" in str(err)
+                  )
               ):
             raise err
 


### PR DESCRIPTION
It seems error messages have changed, making the try-except catches invalid. 

Although not sure about if it would cause backward incompatibility, but for sufficiently new Python version it should be generally okay I guess?

We should probably refactor these in the future though.