### PR TITLE
[FIX] Fix interface changes from nilearn

### DIFF
--- a/neuromaps/datasets/_osf.py
+++ b/neuromaps/datasets/_osf.py
@@ -5,7 +5,11 @@ import os
 from pkg_resources import resource_filename
 import json
 
-from nilearn.datasets.utils import _md5_sum_file
+try:
+    # nilearn 0.10.3
+    from nilearn.datasets._utils import _md5_sum_file
+except ImportError:
+    from nilearn.datasets.utils import _md5_sum_file
 
 from neuromaps.datasets.utils import _get_session
 

--- a/neuromaps/datasets/annotations.py
+++ b/neuromaps/datasets/annotations.py
@@ -8,7 +8,11 @@ import shutil
 import numpy as np
 import warnings
 
-from nilearn.datasets.utils import _fetch_file
+try:
+    # nilearn 0.10.3
+    from nilearn.datasets._utils import fetch_single_file as _fetch_file
+except ImportError:
+    from nilearn.datasets.utils import _fetch_file
 
 from neuromaps.datasets.utils import (get_data_dir, get_dataset_info,
                                       _get_token, _get_session)

--- a/neuromaps/datasets/atlases.py
+++ b/neuromaps/datasets/atlases.py
@@ -5,7 +5,11 @@ from collections import namedtuple
 import os
 from pathlib import Path
 
-from nilearn.datasets.utils import _fetch_files
+try:
+    # nilearn 0.10.3
+    from nilearn.datasets._utils import fetch_files as _fetch_files
+except ImportError:
+    from nilearn.datasets.utils import _fetch_files
 from sklearn.utils import Bunch
 
 from neuromaps.datasets.utils import get_data_dir, get_dataset_info


### PR DESCRIPTION
In nilearn/nilearn/pull/4086 (first released with nilearn 0.10.3), 
- `nilearn.datasets.utils._fetch_files()` was refactored to `nilearn.datasets._utils.fetch_files()`
- `nilearn.datasets.utils._fetch_file()` was refactored to `nilearn.datasets._utils.fetch_single_file()`
- `nilearn.datasets.utils._md5_sum_file()` was refactored to `nilearn.datasets._utils._md5_sum_file()`