### PR TITLE
[ENH] Add BigBrain atlas and transformations

### DIFF
--- a/neuromaps/datasets/__init__.py
+++ b/neuromaps/datasets/__init__.py
@@ -1,10 +1,10 @@
 """Functions for fetching datasets."""
 
 __all__ = [
-    'fetch_all_atlases', 'fetch_atlas', 'fetch_civet', 'fetch_fsaverage',
-    'fetch_fslr', 'fetch_mni152', 'fetch_regfusion', 'get_atlas_dir',
-    'DENSITIES', 'ALIAS', 'available_annotations', 'available_tags',
-    'fetch_annotation'
+    'fetch_all_atlases', 'fetch_atlas', 'fetch_bigbrain', 'fetch_civet',
+    'fetch_fsaverage', 'fetch_fslr', 'fetch_mni152', 'fetch_regfusion',
+    'get_atlas_dir', 'DENSITIES', 'ALIAS', 'available_annotations',
+    'available_tags', 'fetch_annotation'
 ]
 
 # TODO: remove after nilearn v0.9 release
@@ -12,7 +12,7 @@ import warnings
 warnings.filterwarnings('ignore', message='Fetchers from the nilearn.datasets',
                         category=FutureWarning)
 
-from .atlases import (fetch_all_atlases, fetch_atlas, fetch_civet,  # noqa
+from .atlases import (fetch_all_atlases, fetch_atlas, fetch_bigbrain, fetch_civet,  # noqa
                       fetch_fsaverage, fetch_fslr, fetch_mni152,
                       fetch_regfusion, get_atlas_dir, DENSITIES, ALIAS)
 from .annotations import (available_annotations, available_tags,  # noqa

--- a/neuromaps/datasets/atlases.py
+++ b/neuromaps/datasets/atlases.py
@@ -13,13 +13,14 @@ from neuromaps.datasets.utils import get_data_dir, get_dataset_info
 SURFACE = namedtuple('Surface', ('L', 'R'))
 ALIAS = dict(
     fslr='fsLR', fsavg='fsaverage', mni152='MNI152', mni='MNI152',
-    FSLR='fsLR', CIVET='civet'
+    FSLR='fsLR', CIVET='civet', bigbrain='BigBrain'
 )
 DENSITIES = dict(
     civet=['41k', '164k'],
     fsaverage=['3k', '10k', '41k', '164k'],
     fsLR=['4k', '8k', '32k', '164k'],
     MNI152=['1mm', '2mm', '3mm'],
+    BigBrain=['164k']
 )
 
 
@@ -195,6 +196,30 @@ Returns
 -------
 {surfatlas}
 """.format(**_atlas_docs, densities="', '".join(DENSITIES['fsLR']))
+
+
+def fetch_bigbrain(density='164k', url=None, data_dir=None, verbose=1):
+    keys = ['white', 'pial']
+    return _fetch_atlas(
+        'BigBrain', density, keys, url=url, data_dir=data_dir, verbose=verbose
+    )
+
+
+fetch_bigbrain.__doc__ = """
+Fetch BigBrain surface atlas.
+
+Parameters
+----------
+density : {{'{densities}'}}, optional
+    Density of BigBrain atlas to fetch. Default: '164k'
+{url}
+{data_dir}
+{verbose}
+
+Returns
+-------
+{surfatlas}
+""".format(**_atlas_docs, densities="', '".join(DENSITIES['BigBrain']))
 
 
 def fetch_mni152(density='1mm', url=None, data_dir=None, verbose=1): # noqa: D103

--- a/neuromaps/datasets/data/osf.json
+++ b/neuromaps/datasets/data/osf.json
@@ -1,4 +1,13 @@
 {
+    "BigBrain": {
+        "164k": {
+            "url": [
+                "4mw3a",
+                "65c2aa433280d809e3a3aead"
+            ],
+            "md5": "af5e44a36f3d6d0e58d43f0822998c49"
+        }
+    },
     "civet": {
         "41k": {
             "url": [

--- a/neuromaps/transforms.py
+++ b/neuromaps/transforms.py
@@ -619,3 +619,118 @@ def fsaverage_to_fsaverage(data, target_density='41k', hemi=None,
     srcparams = dict(space='fsaverage', den=density, trg='')
     trgparams = dict(space='fsaverage', den=target_density, trg='')
     return _surf_to_surf(data, srcparams, trgparams, method, hemi)
+
+
+def bigbrain_to_fslr(data, target_density='164k', hemi=None, method='linear'):
+    """
+    Resample `data` on the BigBrain surface to the fsLR surface.
+
+    Parameters
+    ----------
+    data : str or os.PathLike or nib.GiftiImage or tuple
+        Input BigBrain data to be resampled
+    target_density : {'4k', '8k', '32k', '164k'}, optional
+        Desired density of output surface. Default: '164k'
+    hemi : {'L', 'R'}, optional
+        If `data` is not a tuple this specifies the hemisphere the data are
+        representing. Default: None
+    method : {'nearest', 'linear'}, optional
+        Method for resampling. Specify 'nearest' if `data` are label images.
+        Default: 'linear'
+
+    Returns
+    -------
+    resampled : tuple-of-nib.GiftiImage
+        Input `data` resampled to new density
+    """
+    density, = _estimate_density((data,), hemi=hemi)
+    srcparams = dict(space='BigBrain', den=density, trg='_space-fsLR')
+    trgparams = dict(space='fsLR', den=target_density, trg='')
+    return _surf_to_surf(data, srcparams, trgparams, method, hemi)
+
+
+def bigbrain_to_fsaverage(data, target_density='164k', hemi=None,
+                          method='linear'):
+    """
+    Resample `data` on the BigBrain surface to the fsaverage surface.
+
+    Parameters
+    ----------
+    data : str or os.PathLike or nib.GiftiImage or tuple
+        Input BigBrain data to be resampled
+    target_density : {'3k', '10k', '41k', '164k'}, optional
+        Desired density of output surface. Default: '164k'
+    hemi : {'L', 'R'}, optional
+        If `data` is not a tuple this specifies the hemisphere the data are
+        representing. Default: None
+    method : {'nearest', 'linear'}, optional
+        Method for resampling. Specify 'nearest' if `data` are label images.
+        Default: 'linear'
+
+    Returns
+    -------
+    resampled : tuple-of-nib.GiftiImage
+        Input `data` resampled to new density
+    """
+    density, = _estimate_density((data,), hemi=hemi)
+    srcparams = dict(space='BigBrain', den=density, trg='_space-fsaverage')
+    trgparams = dict(space='fsaverage', den=target_density, trg='')
+    return _surf_to_surf(data, srcparams, trgparams, method, hemi)
+
+
+def fsaverage_to_bigbrain(data, target_density='164k', hemi=None,
+                          method='linear'):
+    """
+    Resample `data` on fsLR surface to new density.
+
+    Parameters
+    ----------
+    data : str or os.PathLike or nib.GiftiImage or tuple
+        Input BigBrain data to be resampled
+    target_density : {'164k'}, optional
+        Desired density of output surface. Default: '164k'
+    hemi : {'L', 'R'}, optional
+        If `data` is not a tuple this specifies the hemisphere the data are
+        representing. Default: None
+    method : {'nearest', 'linear'}, optional
+        Method for resampling. Specify 'nearest' if `data` are label images.
+        Default: 'linear'
+
+    Returns
+    -------
+    resampled : tuple-of-nib.GiftiImage
+        Input `data` resampled to new density
+    """
+    density, = _estimate_density((data,), hemi=hemi)
+    srcparams = dict(space='fsaverage', den=density, trg='')
+    trgparams = dict(space='BigBrain', den=target_density,
+                     trg='_space-fsaverage')
+    return _surf_to_surf(data, srcparams, trgparams, method, hemi)
+
+
+def fslr_to_bigbrain(data, target_density='164k', hemi=None, method='linear'):
+    """
+    Resample `data` on fsLR surface to new density.
+
+    Parameters
+    ----------
+    data : str or os.PathLike or nib.GiftiImage or tuple
+        Input BigBrain data to be resampled
+    target_density : {'164k'}, optional
+        Desired density of output surface. Default: '164k'
+    hemi : {'L', 'R'}, optional
+        If `data` is not a tuple this specifies the hemisphere the data are
+        representing. Default: None
+    method : {'nearest', 'linear'}, optional
+        Method for resampling. Specify 'nearest' if `data` are label images.
+        Default: 'linear'
+
+    Returns
+    -------
+    resampled : tuple-of-nib.GiftiImage
+        Input `data` resampled to new density
+    """
+    density, = _estimate_density((data,), hemi=hemi)
+    srcparams = dict(space='fsLR', den=density, trg='')
+    trgparams = dict(space='BigBrain', den=target_density, trg='_space-fsLR')
+    return _surf_to_surf(data, srcparams, trgparams, method, hemi)


### PR DESCRIPTION
This PR adds a new BigBrain164k folder to the OSF repo and makes it possible to do surface transformation between [the BigBrain surface](https://bigbrainproject.org/), fsaverage, and fsLR. This is still a work in progress.
Checklist of things to do before merging:
- add BigBrain data to neuromaps (e.g. layer thickness? cell densities?)
- update documentation + annotation_info table
- more testing

Other things to do in the future:
- add transformations between BigBrain and CIVET surface?
- add transformations between MNI152 volume and BigBrain surface?
- update/improve BigBrain surface and medial wall mask (but this would require recomputing the BigBrain data as well)

Much of the work here was already done by the [BigBrainWarp](https://bigbrainwarp.readthedocs.io/en/latest/) so a big shout-out to the BigBrainWarp developers and the BigBrain team (esp Claude Lepage and Lindsay Lewis) :pray: 