### PR TITLE
[REF] Refactor load_data for gifti images with more than one data array

### DIFF
--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -208,7 +208,6 @@ def load_data(data):
             out = np.vstack(data_gii)
         else:
             out = np.hstack(data_gii)
-        # out = np.hstack([load_gifti(img).agg_data() for img in data])
     except (AttributeError, TypeError, ValueError, OSError) as err:
         # niimg_like or path_like (nifti)
         if (isinstance(err, AttributeError)

--- a/neuromaps/images.py
+++ b/neuromaps/images.py
@@ -114,8 +114,8 @@ def fix_coordsys(fn, val=3):
 
 def load_nifti(img):
     """
-    Load nifti file `img`. 
-    
+    Load nifti file `img`.
+
     If `img` is already a loaded (i.e. is a nib.Nifti1Image object),
     it is returned as-is.
 
@@ -196,14 +196,24 @@ def load_data(data):
             or not isinstance(data, Iterable)):
         data = (data,)
 
-    try:
-        # giimg_like or path_like (gifti)
-        out = np.hstack([load_gifti(img).agg_data() for img in data])
+    try:  # giimg_like or path_like (gifti)
+        data_gii = []
+        for img in data:
+            data_hemi = load_gifti(img).agg_data()
+            # More than one data arrays without NIFTI_INTENT_TIMESERIES
+            if isinstance(data_hemi, tuple):
+                data_hemi = np.asarray(data_hemi).T
+            data_gii += [data_hemi]
+        if np.ndim(data_gii) > 2:
+            out = np.vstack(data_gii)
+        else:
+            out = np.hstack(data_gii)
+        # out = np.hstack([load_gifti(img).agg_data() for img in data])
     except (AttributeError, TypeError, ValueError, OSError) as err:
         # niimg_like or path_like (nifti)
         if (isinstance(err, AttributeError)
             or (
-                "os.PathLike" in str(err) 
+                "os.PathLike" in str(err)
                 and "not Nifti1Image" in str(err)
                 )
            ):


### PR DESCRIPTION
This PR refactors the `load_data` function to allow it's use for gifti images with more than one data array (e.g. for timeseries/functional data). There were a few issues with the function, which are related to how the `agg_data` method for GiftiImage objects (from nibabel) handles the intents of data arrays: when the intents of a data array is set to `NIFTI_INTENT_TIMESERIES`, the `agg_data` method returns a 2D ndarray, but when the intents are something else (e.g. `NIFTI_INTENT_SHAPE`), then the data arrays are returned as a tuple of multiple 1D array. The `load_data` was not working as expected in either of these cases (i.e. it couldn't load nor stack data images into numpy arrays).

This PR should fix Issue #139 
