### PR TITLE
[FIX] Fix plotting issue

### DIFF
--- a/neuromaps/nulls/__init__.py
+++ b/neuromaps/nulls/__init__.py
@@ -1,7 +1,7 @@
 """Functions for computing null models."""
 
 __all__ = [
-    'naive_nonparametric', 'alexander_bloch', 'vazquez_rodriguez', 'vasa',
+    'alexander_bloch', 'vazquez_rodriguez', 'vasa',
     'hungarian', 'baum', 'cornblath', 'burt2018', 'burt2020', 'moran'
 ]
 

--- a/neuromaps/plotting.py
+++ b/neuromaps/plotting.py
@@ -82,10 +82,13 @@ def plot_surf_template(data, template, density, surf='inflated',
             ax.disable_mouse_rotation()
             plot_surf(geom, img, hemi=HEMI[hemi], axes=ax, view=view, **opts)
             poly = ax.collections[0]
-            poly.set_facecolors(
-                _fix_facecolors(ax, poly._original_facecolor,
-                                *geom, view, hemi)
-            )
+            try:
+                poly.set_facecolors(
+                    _fix_facecolors(ax, poly._original_facecolor,
+                                    *geom, view, hemi)
+                )
+            except AttributeError:
+                pass
 
     if not opts.get('colorbar', False):
         fig.tight_layout()


### PR DESCRIPTION
Fixing the error: `'Axes3D' object has no attribute '_generate_normals' in neuromaps.plotting.plot_surf_template` by bypassing the shading patch function. This may produce a slightly different figure than previous versions.

The functions have been moved out of the `Poly3DCollection` class to `mpl_toolkits.mplot3d.art3d`. One could try simply call the functions but it did not give nice results for me. Not planning to amend it unless there's a simple solution. 

Fixes #127 