### PR TITLE
[ENH] Add Network Enrichment Significance Testing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -207,6 +207,7 @@ Parametric spatial null models (for volumetric and surface images)
 
     neuromaps.stats.compare_images
     neuromaps.stats.permtest_metric
+    neuromaps.stats.sw_nest
 
 .. _ref_transforms:
 


### PR DESCRIPTION
This PR adds Network Enrichment Significance Testing (NEST) from Weinstein et al., 2024. 

The original implementation is [here](https://github.com/smweinst/NEST). We left out the modules for linear models to keep it consistent with what neuromaps would provide.

This is just a draft. All suggestions are welcome.