### PR TITLE
[MNT] Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,11 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = [
+  "neuromaps",
+  "neuromaps.*"
+]
 
 [tool.setuptools.package-data]
 "*" = ["*.json", "*.bib"]


### PR DESCRIPTION
Updating `pyproject.toml` so that `docs` and `examples` folders will not appear in the top-level of `site-packages`.