### PR TITLE
[FIX] fix nilearn interface update for fetch_single_file

### DIFF
--- a/neuromaps/datasets/annotations.py
+++ b/neuromaps/datasets/annotations.py
@@ -285,7 +285,7 @@ def fetch_annotation(*, source=None, desc=None, space=None, den=None, res=None,
     for dset in info:
         fn = Path(data_dir) / 'annotations' / dset['rel_path'] / dset['fname']
         if not fn.exists():
-            dl_file = _fetch_file(dset['url'], str(fn.parent), verbose=verbose,
+            dl_file = _fetch_file(dset['url'], fn.parent, verbose=verbose,
                                   md5sum=dset['checksum'], session=session)
             shutil.move(dl_file, fn)
         data.append(str(fn))

--- a/neuromaps/datasets/tests/test_annotations.py
+++ b/neuromaps/datasets/tests/test_annotations.py
@@ -32,6 +32,11 @@ def test_available_tags():
     assert all(f in restricted for f in unrestricted)
 
 
+def test_fetch_annotation_smoke():
+    """Smoke test of fetching an annotation."""
+    annotations.fetch_annotation(source="abagen")
+
+
 @pytest.mark.xfail
 def test_fetch_annotation():
     """Test fetching an annotation."""


### PR DESCRIPTION
Thanks to #185 for raising this issue.

The breaking change comes from nilearn/nilearn#4725, and first appears in [0.11.0](https://github.com/nilearn/nilearn/releases/tag/0.11.0).