### PR TITLE
[FIX] Fix `_chk2_asarray` dependency

### DIFF
--- a/neuromaps/stats.py
+++ b/neuromaps/stats.py
@@ -5,10 +5,7 @@ from functools import partial
 
 import numpy as np
 from scipy import special, stats as sstats
-try:
-    from scipy.stats._stats_py import _chk2_asarray  # scipy >= 1.8.0
-except ImportError:
-    from scipy.stats.stats import _chk2_asarray  # scipy < 1.8.0
+from neuromaps.utils import _chk2_asarray
 from sklearn.utils.validation import check_random_state
 
 from neuromaps.images import load_data

--- a/neuromaps/utils.py
+++ b/neuromaps/utils.py
@@ -2,6 +2,7 @@
 """Utility functions."""
 
 import os
+import numpy as np
 from pathlib import Path
 import tempfile
 import subprocess
@@ -125,3 +126,27 @@ def check_fs_subjid(subject_id, subjects_dir=None):
                                 .format(subject_id, subjects_dir))
 
     return subject_id, subjects_dir
+
+
+def _chk2_asarray(a, b, axis):
+    """
+    Evaluate and converts two input sequences into validated NumPy arrays.
+
+    This function was in the private API of scipy, but was recently removed:
+    https://github.com/scipy/scipy/pull/23088
+    """
+    if axis is None:
+        a = np.ravel(a)
+        b = np.ravel(b)
+        outaxis = 0
+    else:
+        a = np.asarray(a)
+        b = np.asarray(b)
+        outaxis = axis
+
+    if a.ndim == 0:
+        a = np.atleast_1d(a)
+    if b.ndim == 0:
+        b = np.atleast_1d(b)
+
+    return a, b, outaxis


### PR DESCRIPTION
This PR adds a `_chk2_asarray` function to replace the scipy function that was [recently removed](https://github.com/scipy/scipy/pull/23088/changes)