### PR TITLE
Fix single-hemisphere NumPy array conversion

### DIFF
--- a/neuromaps/parcellate.py
+++ b/neuromaps/parcellate.py
@@ -19,9 +19,10 @@ def _gifti_to_array(gifti):
     return np.hstack([load_gifti(img).agg_data() for img in gifti])
 
 
-def _array_to_gifti(data):
+def _array_to_gifti(data, hemi=None):
     """Convert numpy `array` to tuple of gifti images."""
-    return tuple(construct_shape_gii(arr) for arr in np.split(data, 2))
+    arrays = (data,) if hemi is not None else np.split(data, 2)
+    return tuple(construct_shape_gii(array) for array in arrays)
 
 
 class Parcellater():
@@ -147,7 +148,7 @@ class Parcellater():
                                  'nibabel.nifti1.Nifti1Image to construct a '
                                  'Nifti1Image from your array.')
             else:
-                data = _array_to_gifti(data)
+                data = _array_to_gifti(data, hemi=hemi)
         if self.resampling_target in ('data', None):
             resampling_method = 'nearest'
         else:

--- a/neuromaps/tests/test_parcellate.py
+++ b/neuromaps/tests/test_parcellate.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 """For testing neuromaps.parcellate functionality."""
 
+import numpy as np
 import pytest
+
+from neuromaps import parcellate
+from neuromaps.images import construct_shape_gii
 
 
 @pytest.mark.xfail
@@ -10,10 +14,40 @@ def test__gifti_to_array():
     assert False
 
 
-@pytest.mark.xfail
-def test__array_to_gifti():
+@pytest.mark.parametrize('hemi, n_images, n_vertices', [
+    (None, 2, (321, 321)),
+    ('L', 1, (642,)),
+    ('R', 1, (642,)),
+])
+def test__array_to_gifti(hemi, n_images, n_vertices):
     """Test converting array to gifti."""
-    assert False
+    images = parcellate._array_to_gifti(np.arange(642), hemi=hemi)
+
+    assert len(images) == n_images
+    assert tuple(len(image.agg_data()) for image in images) == n_vertices
+
+
+def test_Parcellater_single_hemi_array(monkeypatch):
+    """Test parcellating single-hemisphere array data."""
+    labels = np.ones(642, dtype=int)
+    labels[0] = 0
+    atlas = construct_shape_gii(
+        labels,
+        intent='NIFTI_INTENT_LABEL',
+        labels=['background', 'parcel'],
+    )
+
+    def _resample_images(data, parc, *args, **kwargs):
+        assert len(data) == 1
+        assert len(data[0].agg_data()) == 642
+        return data, parc
+
+    monkeypatch.setattr(parcellate, 'resample_images', _resample_images)
+    result = parcellate.Parcellater(
+        atlas, 'fsaverage', resampling_target=None, hemi='L'
+    ).fit_transform(np.arange(642), 'fsaverage', hemi='L')
+
+    assert result == pytest.approx(321.0)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
Fixes #216.

## Summary
- preserve a single surface array when `hemi="L"` or `hemi="R"` is provided
- retain the existing left/right split for bilateral arrays
- add regression coverage for bilateral and single-hemisphere inputs through `Parcellater.fit_transform`

## Testing
- `NEUROMAPS_DATA=/tmp/neuromaps-data python -m pytest -q`
- `python -m ruff check neuromaps/parcellate.py neuromaps/tests/test_parcellate.py`
- `git diff --check`