### PR TITLE
Rank supplied null maps consistently for Spearman correlations

### DIFF
--- a/neuromaps/stats.py
+++ b/neuromaps/stats.py
@@ -67,11 +67,15 @@ def compare_images(src, trg, metric='pearsonr', ignore_zero=True, nulls=None,
 
     srcdata, trgdata = load_data(src), load_data(trg)
 
+    if nan_policy not in ('propagate', 'raise', 'omit'):
+        raise ValueError(f'Value for nan_policy "{nan_policy}" not allowed')
+
     # drop NaNs (if nan_policy==`omit`) and zeros (if ignore_zero=True)
     zeromask = np.zeros(len(srcdata), dtype=bool)
     if ignore_zero:
         zeromask = np.logical_or(np.isclose(srcdata, 0),
                                  np.isclose(trgdata, 0))
+    mask = np.logical_not(zeromask)
     nanmask = np.logical_or(np.isnan(srcdata), np.isnan(trgdata))
     if nan_policy == 'raise':
         if np.any(nanmask):
@@ -83,20 +87,50 @@ def compare_images(src, trg, metric='pearsonr', ignore_zero=True, nulls=None,
         mask = np.logical_not(zeromask)
     srcdata, trgdata = srcdata[mask], trgdata[mask]
 
-    if metric in methods:
-        if metric == 'spearmanr':
-            srcdata = sstats.rankdata(srcdata)
-            trgdata = sstats.rankdata(trgdata)
-        metric = partial(efficient_pearsonr, return_pval=False)
-
     if nulls is not None:
+        # Preserve the metric name: permtest_metric must apply exactly the
+        # same statistic to the observed maps and to every supplied null map.
         n_perm = nulls.shape[-1]
         nulls = nulls[mask]
         return permtest_metric(srcdata, trgdata, metric, n_perm=n_perm,
                                nulls=nulls, nan_policy=nan_policy,
                                return_nulls=return_nulls)
 
+    if metric == 'spearmanr':
+        return _spearmanr(srcdata, trgdata, nan_policy=nan_policy)
+    if metric == 'pearsonr':
+        return efficient_pearsonr(srcdata, trgdata, return_pval=False,
+                                  nan_policy=nan_policy)
     return metric(srcdata, trgdata)
+
+
+def _spearmanr(a, b, nan_policy='propagate'):
+    """Compute matching-column rank correlations on each pair's support."""
+    if nan_policy not in ('propagate', 'raise', 'omit'):
+        raise ValueError(f'Value for nan_policy "{nan_policy}" not allowed')
+    a, b, _ = _chk2_asarray(a, b, 0)
+    if len(a) != len(b):
+        raise ValueError('Provided arrays do not have same length')
+    if a.size == 0 or b.size == 0:
+        return np.nan
+    a, b = np.broadcast_arrays(a.reshape(len(a), -1),
+                               b.reshape(len(b), -1))
+    correlations = np.full(a.shape[1], np.nan)
+    for column in range(a.shape[1]):
+        x, y = a[:, column], b[:, column]
+        missing = np.isnan(x) | np.isnan(y)
+        if nan_policy == 'raise' and np.any(missing):
+            raise ValueError('Input contains nan')
+        if nan_policy == 'propagate' and np.any(missing):
+            continue
+        if nan_policy == 'omit':
+            x, y = x[~missing], y[~missing]
+        if len(x) < 2 or np.all(x == x[0]) or np.all(y == y[0]):
+            continue
+        # Ranking must happen after pairwise omission, separately for every
+        # null comparison. Original-map ranks are not valid for a new support.
+        correlations[column] = sstats.spearmanr(x, y)[0]
+    return np.squeeze(correlations) / 1
 
 
 def permtest_metric(a, b, metric='pearsonr', n_perm=1000, seed=0, nulls=None,
@@ -147,6 +181,13 @@ def permtest_metric(a, b, metric='pearsonr', n_perm=1000, seed=0, nulls=None,
 
     Notes
     -----
+    For Spearman comparisons, observed data and every null map are ranked
+    separately after pairwise NaN handling. Supplied null maps may contain raw
+    values; callers do not need to pre-rank them. If any Spearman statistic is
+    undefined, its p-value is NaN rather than treating that draw as evidence
+    against the null. The supplied null-generation model remains the caller's
+    responsibility.
+
     The lowest p-value that can be returned by this function is equal to 1 /
     (`n_perm` + 1).
     """
@@ -169,10 +210,9 @@ def permtest_metric(a, b, metric='pearsonr', n_perm=1000, seed=0, nulls=None,
     if a.size == 0 or b.size == 0:
         return np.nan, np.nan
 
-    methods = ('pearsonr', 'spearmanr')
-    if metric in methods:
-        if metric == 'spearmanr':
-            a, b = sstats.rankdata(a), sstats.rankdata(b)
+    if metric == 'spearmanr':
+        compfunc = _spearmanr
+    elif metric == 'pearsonr':
         compfunc = partial(efficient_pearsonr, return_pval=False)
     else:
         compfunc = nan_wrap
@@ -183,6 +223,9 @@ def permtest_metric(a, b, metric='pearsonr', n_perm=1000, seed=0, nulls=None,
     # divide by one forces coercion to float if ndim = 0
     true_sim = compfunc(a, b, nan_policy=nan_policy) / 1
     abs_true = np.abs(true_sim)
+    if metric == 'spearmanr':
+        # Count theoretical ties despite rounding in correlation arithmetic.
+        abs_true = abs_true - 100 * np.finfo(float).eps * abs_true
 
     permutations = np.ones(true_sim.shape)
     nulldist = np.zeros(((n_perm, ) + true_sim.shape))
@@ -194,6 +237,12 @@ def permtest_metric(a, b, metric='pearsonr', n_perm=1000, seed=0, nulls=None,
         nulldist[perm] = nullcomp
 
     pvals = permutations / (n_perm + 1)  # + 1 in denom accounts for true_sim
+    if metric == 'spearmanr':
+        # An undefined observed or null statistic is not a non-exceedance.
+        # Do not silently turn a failed comparison into a small p-value.
+        invalid = (~np.isfinite(true_sim)
+                   | np.any(~np.isfinite(nulldist), axis=0))
+        pvals = np.where(invalid, np.nan, pvals) / 1
 
     if return_nulls:
         return true_sim, pvals, nulldist

--- a/neuromaps/tests/test_stats_spearman_nulls.py
+++ b/neuromaps/tests/test_stats_spearman_nulls.py
@@ -1,0 +1,229 @@
+"""Regression tests for rank-consistent observed and supplied-null statistics."""
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+from scipy.stats import spearmanr, rankdata, pearsonr
+from neuromaps import stats
+
+
+def reference(a, b, nulls, nan_policy='propagate'):
+    r = spearmanr(a, b, nan_policy=nan_policy)[0]
+    d = np.array([spearmanr(c, b, nan_policy=nan_policy)[0]
+                  for c in nulls.T])
+    if not np.isfinite(r) or not np.all(np.isfinite(d)):
+        p = np.nan
+    else:
+        threshold = abs(r) - 100 * np.finfo(float).eps * abs(r)
+        p = (1 + np.count_nonzero(abs(d) >= threshold)) / (len(d) + 1)
+    return r, p, d
+
+
+def ring_fixture():
+    n = 100
+    theta = 2 * np.pi * np.arange(n) / n
+    base = 2 + np.sin(theta + .123) + .17 * np.sin(3 * theta + .257)
+    a = rankdata(base)
+    a[a == n] = 1e8  # Strictly increasing rescaling of distinct source ranks.
+    b = 2 + np.sin(theta + 1.111) + .13 * np.cos(2 * theta + .421)
+    nulls = np.column_stack([np.roll(a, k) for k in range(1, n)])
+    return a, b, nulls
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+@pytest.mark.parametrize('seed', range(10))
+def test_external_nulls_match_independent_spearman(entry, seed):
+    rng = np.random.default_rng(seed)
+    a = rng.lognormal(0, 2, 31)
+    b = rng.normal(size=31)
+    nulls = np.column_stack([rng.permutation(a) for _ in range(29)])
+    actual = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls,
+                                   return_nulls=True)
+    expected = reference(a, b, nulls)
+    for x, y in zip(actual, expected):
+        assert_allclose(x, y, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_circular_shift_significance_and_monotonic_invariance(entry):
+    a, b, nulls = ring_fixture()
+    f = getattr(stats, entry)
+    raw = f(a, b, metric='spearmanr', nulls=nulls, return_nulls=True)
+    ranked = f(rankdata(a), b, metric='spearmanr',
+               nulls=rankdata(nulls, axis=0), return_nulls=True)
+    expected = reference(a, b, nulls)
+    assert_allclose(raw[0], .5778217821782178, atol=1e-14)
+    assert_allclose(raw[1], .60, atol=1e-14)
+    for x, y, z in zip(raw, ranked, expected):
+        assert_allclose(x, y, atol=1e-14)
+        assert_allclose(x, z, atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_ties_and_identity_draw(entry):
+    a = np.array([1., 1., 2., 4., 4., 4., 8., 9.])
+    b = np.array([1., 3., 3., 6., 6., 9., 7., 9.])
+    nulls = np.column_stack([a, a[::-1], np.roll(a, 2), np.roll(a, 3)])
+    result = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls,
+                                   return_nulls=True)
+    for x, y in zip(result, reference(a, b, nulls)):
+        assert_allclose(x, y, atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_null_specific_nan_omission_ranks_on_pairwise_support(entry):
+    a = np.array([1., 3., 2., 7., 4., 9., 8., 10.])
+    b = np.array([5., 1., 6., 2., 8., 4., 9., 10.])
+    nulls = np.column_stack([np.roll(a, k) for k in (1, 2, 3)])
+    nulls[[1, 3, 6], [0, 1, 2]] = np.nan
+    result = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls,
+                                   nan_policy='omit', return_nulls=True)
+    for x, y in zip(result, reference(a, b, nulls, 'omit')):
+        assert_allclose(x, y, atol=1e-14)
+
+
+def test_observed_nan_omission_direct():
+    a = np.array([1., np.nan, 3., 8., 4., 9., 7.])
+    b = np.array([2., 5., 4., 3., np.nan, 9., 8.])
+    nulls = np.column_stack([np.roll(a, k) for k in (1, 2, 3)])
+    actual = stats.permtest_metric(a, b, metric='spearmanr', nulls=nulls,
+                                   nan_policy='omit', return_nulls=True)
+    for x, y in zip(actual, reference(a, b, nulls, 'omit')):
+        assert_allclose(x, y, atol=1e-14)
+
+
+def test_compare_mask_applied_before_ranking_nulls():
+    a = np.array([0., 1., 3., 2., 7., 4., 9., 8., np.nan])
+    b = np.array([9., 5., 1., 6., 2., 8., 4., 9., 10.])
+    nulls = np.column_stack([np.roll(np.nan_to_num(a, nan=10.), k)
+                            for k in (1, 2, 3)])
+    mask = ~np.isclose(a, 0) & ~np.isnan(a)
+    actual = stats.compare_images(a, b, metric='spearmanr', nulls=nulls,
+                                   return_nulls=True)
+    for x, y in zip(actual, reference(a[mask], b[mask], nulls[mask])):
+        assert_allclose(x, y, atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_nan_raise_accepts_finite_inputs_and_rejects_nan(entry):
+    a, b, nulls = ring_fixture()
+    f = getattr(stats, entry)
+    result = f(a, b, metric='spearmanr', nulls=nulls, nan_policy='raise')
+    assert_allclose(result[1], .60)
+    nulls[0, 0] = np.nan
+    with pytest.raises(ValueError, match='nan'):
+        f(a, b, metric='spearmanr', nulls=nulls, nan_policy='raise')
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+@pytest.mark.parametrize('where', ['observed', 'null'])
+def test_undefined_statistic_does_not_produce_significant_p(entry, where):
+    a, b, nulls = ring_fixture()
+    if where == 'observed':
+        b[:] = 1.0
+    else:
+        nulls[:, 0] = 1.0
+    result = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls)
+    assert np.isnan(result[1])
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_nan_propagate_does_not_produce_significant_p(entry):
+    a, b, nulls = ring_fixture()
+    nulls[0, 0] = np.nan
+    result = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls,
+                                   nan_policy='propagate')
+    assert np.isnan(result[1])
+
+
+def test_internal_and_equivalent_external_permutations_match():
+    a, b, _ = ring_fixture()
+    rng = np.random.RandomState(42)
+    nulls = np.column_stack([a[rng.permutation(len(a))] for _ in range(31)])
+    internal = stats.permtest_metric(a, b, metric='spearmanr', n_perm=31,
+                                    seed=42, return_nulls=True)
+    external = stats.permtest_metric(a, b, metric='spearmanr', nulls=nulls,
+                                    return_nulls=True)
+    for x, y in zip(internal, external):
+        assert_allclose(x, y, atol=1e-14)
+
+
+def test_spearman_matching_columns_and_broadcasting():
+    rng = np.random.default_rng(43)
+    a = rng.lognormal(size=(15, 2))
+    b = rng.normal(size=(15, 1))
+    actual = stats.permtest_metric(a, b, metric='spearmanr', n_perm=17,
+                                   return_nulls=True)
+    expected = [stats.permtest_metric(a[:, j], b[:, 0], metric='spearmanr',
+                                     n_perm=17, return_nulls=True)
+                for j in range(2)]
+    assert_allclose(actual[0], [x[0] for x in expected])
+    assert_allclose(actual[1], [x[1] for x in expected])
+    assert_allclose(actual[2], np.column_stack([x[2] for x in expected]))
+
+
+@pytest.mark.parametrize('policy', ['omit', 'propagate', 'raise'])
+def test_compare_without_nulls(policy):
+    a, b, _ = ring_fixture()
+    actual = stats.compare_images(a, b, metric='spearmanr', nan_policy=policy)
+    assert_allclose(actual, spearmanr(a, b)[0], atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_inputs_not_mutated(entry):
+    a, b, nulls = ring_fixture()
+    before = [x.copy() for x in (a, b, nulls)]
+    for x in (a, b, nulls):
+        x.flags.writeable = False
+    getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls)
+    for x, y in zip((a, b, nulls), before):
+        assert_array_equal(x, y)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_invalid_nan_policy(entry):
+    a, b, nulls = ring_fixture()
+    with pytest.raises(ValueError, match='nan_policy'):
+        getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls,
+                              nan_policy='invalid')
+
+
+def test_pearson_external_nulls_unchanged():
+    rng = np.random.default_rng(4321)
+    a, b = rng.normal(size=(2, 25))
+    nulls = rng.normal(size=(25, 19))
+    r, p, d = stats.permtest_metric(a, b, metric='pearsonr', nulls=nulls,
+                                   return_nulls=True)
+    ref_r = pearsonr(a, b)[0]
+    ref_d = np.array([pearsonr(v, b)[0] for v in nulls.T])
+    ref_p = (1 + sum(abs(ref_d) >= abs(ref_r))) / 20
+    assert_allclose(r, ref_r)
+    assert_allclose(d, ref_d)
+    assert_allclose(p, ref_p)
+
+
+def test_custom_callable_not_rank_transformed():
+    a = np.arange(1., 10.) ** 2
+    b = np.arange(2., 11.)
+    nulls = np.column_stack([a[::-1], np.roll(a, 3)])
+    metric = lambda x, y: np.mean(x * y)
+    actual = stats.permtest_metric(a, b, metric=metric, nulls=nulls,
+                                   return_nulls=True)
+    assert_allclose(actual[0], metric(a, b))
+    assert_allclose(actual[2], [metric(v, b) for v in nulls.T])
+
+
+def test_callable_workaround_avoids_affected_string_dispatch():
+    a, b, nulls = ring_fixture()
+    metric = lambda x, y: spearmanr(x, y)[0]
+    actual = stats.compare_images(a, b, metric=metric, nulls=nulls,
+                                   return_nulls=True)
+    for x, y in zip(actual, reference(a, b, nulls)):
+        assert_allclose(x, y, atol=1e-14)
+
+
+@pytest.mark.parametrize('entry', ['permtest_metric', 'compare_images'])
+def test_scalar_inputs_return_scalar_statistics(entry):
+    a, b, nulls = ring_fixture()
+    r, p = getattr(stats, entry)(a, b, metric='spearmanr', nulls=nulls)
+    assert np.isscalar(r)
+    assert np.isscalar(p)


### PR DESCRIPTION
# [FIX] Apply Spearman consistently to observed and supplied-null maps

## Summary

`compare_images(..., metric='spearmanr', nulls=...)` and
`permtest_metric(..., metric='spearmanr', nulls=...)` currently compare an observed
Spearman coefficient against a different null statistic: Pearson correlation
between an **unranked** supplied null map and a **ranked** target.

Confirmed against release 0.0.7 / commit
`ffcc2e0f657943ce00a1b6a968396f32250e495c`, with the source verified against Git blob
`077f22d1a862e042e82635c46d8f892eddd1d943`.

This can change the inferential conclusion without changing any ranks. It occurs
with entirely finite, nonzero inputs, independently of masking issue #196.

## Minimal native reproduction

```python
import numpy as np
from scipy.stats import rankdata, spearmanr
from neuromaps.stats import compare_images

n = 100
t = 2 * np.pi * np.arange(n) / n
base = 2 + np.sin(t + .123) + .17 * np.sin(3*t + .257)
a = rankdata(base)
a[a == n] = 1e8
b = 2 + np.sin(t + 1.111) + .13 * np.cos(2*t + .421)
nulls = np.column_stack([np.roll(a, k) for k in range(1, n)])
r, p = compare_images(a, b, metric='spearmanr', nulls=nulls)
observed = spearmanr(a, b)[0]
null_r = np.array([spearmanr(v, b)[0] for v in nulls.T])
threshold = abs(observed) - 100*np.finfo(float).eps*abs(observed)
reference_p = (1 + np.count_nonzero(abs(null_r) >= threshold)) / n
print(r, p, reference_p)
# Affected source: approximately 0.5778217821782178, 0.01, 0.60
# Patched source:  approximately 0.5778217821782178, 0.60, 0.60
```

These are synthetic circular-shift null maps, not empirical cortical maps. A
smaller rescaling of the largest rank from 100 to 1000 also yields p=0.01 instead
of 0.60 in this fixture. The full packet records a graded rescaling sweep.

## Change

Preserve the named metric when `compare_images` forwards supplied null maps.
Apply the same Spearman calculation to the observed maps and every null draw,
ranking after pairwise NaN omission where requested. A private helper preserves
matching-column/broadcasting behavior and handles ties through SciPy.

The patch also defines the necessary edge behavior: theoretical Spearman ties
receive a floating-point comparison tolerance; undefined observed or null
Spearman statistics give an undefined p-value rather than a fabricated minimum
p-value. The `raise` mask path and invalid-policy validation are made explicit.
These NaN/validation improvements are not presented as independent novel findings.
The scientific validity of the caller's null-generation or missing-data model is
not changed or guaranteed.

## Validation completed

An isolated execution of the exact numerical module, with ndarray-only I/O
adapters, gives **56 passed, 1 pre-existing xfail**. The same tests on the unpatched
source give **40 failed, 16 passed, 1 pre-existing xfail**. There are 50 new
regression cases and six existing passing statistics cases.

Tests cover both entry points, ten fixed random seeds, every returned null
coefficient, monotonic invariance, tied values, identity draws, pairwise missing
values, invalid and valid policies, undefined statistics, matching columns,
internal/external permutation equivalence, scalar output, no input mutation,
Pearson controls, and custom callable controls.

All 100 orientations of a constructed cyclic null orbit were also enumerated.
The original source rejects 90/100 at p<0.05; the patch and an independent
integer-rank reference reject 4/100. This is a stress-test result, not an estimate
of error prevalence in neuroscience publications.

`git apply --check` succeeds against the pinned source, and applying the patch
reconstructs the tested modified source byte-for-byte.

## Validation still required before merge

Native installed-package statistics tests and the complete upstream integration
suite, supported dependency-version CI, and a realistic large-map performance
check. The isolated run does not exercise NIfTI/GIFTI loading, atlas downloads,
or actual cortical spatial-null generation. The native reproduction and test
commands are supplied, but were not run here.

No claim is made that the neuromaps methods paper or any empirical paper is
invalidated. A specific downstream call site is documented separately for
reanalysis. Please flag any earlier report or planned fix so it receives credit.
